### PR TITLE
Enable analyses from the Hopla web interface

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ The package manual is [docs/README.md](docs/README.md).
   - `hopla convert LEGACY [OUTPUT]`
   - `hopla concordance FLOW1 FLOW2 [-r]`
   - `hopla transform FLOW1 FLOW2 MODE [OUTPUT]`
-  - `hopla serve [--host HOST] [--port PORT] [--no-open]`
+  - `hopla serve [--host HOST] [--port PORT] [--no-open] [--no-analysis]`
 - `vcf_file`, `out_dir`, and `cytoband_file` are CLI paths, not settings properties. Validate that supplied paths exist. `OUT_DIR` defaults to the current working directory; an omitted cytoband table is downloaded from UCSC.
 - Default `run` also writes `{fam_id}-export/` Parquet and IGV sidecars unless disabled with `--no-export-parquet` / `--no-export-bigwig`.
 - `convert` maps the legacy `key=value` settings format to schema-validated YAML.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ subtools. Historical notes from the predecessor analysis pipeline live in
 - Replaced pixi features and environments `hopla-py` / `hopla-py-dev` with the default environment plus `dev`.
 - Merged the pixi workspace into `pyproject.toml` (`[tool.pixi…]`) and dropped `pixi.toml`.
 - Kept `pixi.lock` free of PyPI source dependencies; it resolves conda packages only.
+- Extended `hopla serve` to run the current browser configuration with an
+  uploaded VCF and return a temporary self-contained HTML report.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ subtools. Historical notes from the predecessor analysis pipeline live in
 - Merged the pixi workspace into `pyproject.toml` (`[tool.pixi…]`) and dropped `pixi.toml`.
 - Kept `pixi.lock` free of PyPI source dependencies; it resolves conda packages only.
 - Extended `hopla serve` to run the current browser configuration with an
-  uploaded VCF and return a temporary self-contained HTML report.
+  uploaded VCF and return a temporary self-contained HTML report, with a live
+  step log and a `--no-analysis` flag that serves settings editing only.
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ This repository holds the typed Python package `hopla` (version 3.0.0).
 
 - A (multisample) `vcf.gz` file.
 - A YAML or JSON [settings file](docs/settings.md) describing the family and analysis options. Create it by hand or with the optional local [`hopla serve`](docs/serve.md) editor.
-- The VCF path and output directory are command-line arguments, not settings keys.
+- For CLI runs, the VCF path and output directory are command-line arguments,
+  not settings keys. The local web interface can instead upload a selected VCF
+  and return a temporary HTML report.
 
 ## Quick start
 
@@ -42,6 +44,10 @@ pixi run hopla run example/settings.yaml path/to/family.vcf.gz
 By default `hopla run` also writes `{fam_id}-export/` with Parquet tables and
 IGV desktop tracks. See [exports.md](docs/exports.md). Example settings and a
 legacy conversion fixture are in [`example/`](example/).
+
+`hopla serve` can create or import settings, upload a VCF selected in the
+browser, run the analysis, and return its HTML report. Web runs use temporary
+storage and omit the Parquet and IGV exports.
 
 ```bash
 hopla run settings.yaml family.vcf.gz

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,8 +34,9 @@ This manual documents the Python package at the repository root. Start from the
 - A YAML or JSON [settings file](settings.md) describing the family and
   analysis options. Create it by hand or with the optional local
   [`hopla serve`](serve.md) editor.
-- The VCF path and output directory are command-line arguments, not settings
-  keys.
+- For CLI runs, the VCF path and output directory are command-line arguments,
+  not settings keys. The local web interface can instead upload a selected VCF
+  and return a temporary HTML report.
 
 ## Quick start
 
@@ -51,6 +52,9 @@ offline HTML report. By default it also writes portable Parquet tables and IGV
 desktop tracks under `{fam_id}-export/`. Merlin 1.1.2 remains an optional
 external dependency for haplotyping. Example settings live in
 [`example/`](../example/).
+
+Alternatively, run `pixi run hopla serve` to create or import settings, select
+a VCF in the browser, and download the generated HTML report.
 
 ## Maintainers and contact
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -7,7 +7,8 @@ manual under `docs/`.
 ```text
 pyproject.toml              package metadata, console script, tool config
 src/hopla/__init__.py       package version
-src/hopla/cli.py            Typer dispatcher and run orchestration
+src/hopla/cli.py            Typer command-line dispatcher
+src/hopla/pipeline.py       shared analysis orchestration
 src/hopla/settings.py       schema validation and pedigree defaults
 src/hopla/vcf.py            cyvcf2 streaming into SiteTable / matrices
 src/hopla/filters.py        filter 1 and filter 2 masks
@@ -18,7 +19,7 @@ src/hopla/flow.py           concordance / transform helpers
 src/hopla/convert.py        legacy key=value → YAML conversion
 src/hopla/cytobands.py      UCSC cytoband load / download
 src/hopla/report.py         self-contained HTML report assembly
-src/hopla/serve.py          Starlette settings-editor application
+src/hopla/serve.py          Starlette settings and analysis application
 src/hopla/ui/               form mapping, Jinja template, CSS, and JavaScript
 src/hopla/export/           Parquet and IGV desktop exporters
 src/hopla/models.py         shared typed tables and chromosome constants
@@ -55,31 +56,38 @@ aggregation; NumPy owns dense genotype operations. Merlin 1.1.2 remains an
 external executable so its haplotyping inference stays compatible with prior
 Hopla Merlin workflows.
 
-`cli.py` owns command-line parsing, logging setup, temporary cytoband download
-lifetime, pipeline orchestration, and output writes. Individual modules define
-helpers only; reordering imports or calling one module in isolation is not a
-supported public API beyond the console script.
+`cli.py` owns command-line parsing and logging setup. `pipeline.py` owns the
+shared analysis sequence, temporary cytoband download lifetime, and output
+writes used by the CLI and web interface. Individual analysis modules define
+the narrower helpers called by that sequence.
 
-## Settings editor flow
+## Web interface flow
 
 `hopla serve` starts the Starlette application in `serve.py` through Uvicorn.
 The application serves package-local Jinja, CSS, and JavaScript assets from
 `ui/`. Browser form state is stateless: preview, import, and download requests
 carry the complete form model. `ui/form.py` converts that model to schema-valid
 settings and reconstructs the youngest pedigree from imported legacy,
-YAML, or JSON settings. The editor does not accept VCFs or run analyses.
+YAML, or JSON settings.
+
+For an analysis, the application validates the current form, allocates a
+randomly identified job directory under an application-lifetime temporary
+directory, and streams the selected VCF into it. The blocking shared pipeline
+runs in a worker thread while the browser polls coarse job status. Web jobs
+disable portable and IGV exports; the completed HTML report remains available
+for download until the server stops.
 
 ## Change placement
 
-- Keep command parsing and `run` orchestration in `cli.py`.
+- Keep command parsing in `cli.py` and shared run orchestration in `pipeline.py`.
 - Keep settings validation and derived defaults in `settings.py`.
 - Put VCF loading and genotype matrices in `vcf.py`.
 - Put filter masks in `filters.py`.
 - Put analysis tables in `analysis.py`.
 - Put Merlin execution and haplotype correction in `merlin.py`.
 - Put report HTML assembly in `report.py`.
-- Put settings-editor HTTP routes in `serve.py` and form mapping/assets in
-  `ui/`.
+- Put settings and analysis HTTP routes in `serve.py` and form mapping/assets
+  in `ui/`.
 - Put portable / IGV exporters under `export/`.
 - Add behavior coverage under `tests/`.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -93,10 +93,12 @@ hopla serve --no-open
 hopla serve --host 0.0.0.0 --port 8080
 ```
 
-The editor imports legacy `.txt` and current YAML/JSON settings, reconstructs
-the pedigree, validates changes against the packaged schema, and downloads
-YAML for `hopla run`. It does not accept VCFs or run analyses. See
-[serve.md](serve.md) for usage and network-safety details.
+The web interface imports legacy `.txt` and current YAML/JSON settings,
+reconstructs the pedigree, validates changes against the packaged schema, and
+downloads YAML for `hopla run`. It can also stream a locally selected VCF,
+run an analysis with the current configuration, and return the self-contained
+HTML report. Web analyses use temporary storage and do not write Parquet or IGV
+exports. See [serve.md](serve.md) for usage and network-safety details.
 
 ## Convert, concordance, and transform
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -13,7 +13,7 @@ hopla [-hV] [-L LEVEL] convert LEGACY [OUTPUT]
 hopla [-hV] [-L LEVEL] concordance [-r] FLOW1 FLOW2
 hopla [-hV] [-L LEVEL] transform FLOW1 FLOW2 MODE [OUTPUT]
 hopla [-hV] [-L LEVEL] serve [--host HOST] [--port PORT]
-      [--open|--no-open]
+      [--open|--no-open] [--analysis|--no-analysis]
 ```
 
 `-L` may also appear among `run` options, before the settings and VCF operands.
@@ -49,6 +49,8 @@ hopla [-hV] [-L LEVEL] serve [--host HOST] [--port PORT]
   `<flow1>-relative.txt`.
 - `serve` starts the local browser settings editor. It binds
   `127.0.0.1:8080` by default and opens a browser when run interactively.
+  `--no-analysis` serves settings only: the Analysis tab is not rendered and
+  the analysis endpoints are not registered.
 
 `concordance` accepts `-r` only before its operands.
 
@@ -91,6 +93,7 @@ Complete example: [`example/settings.yaml`](../example/settings.yaml).
 hopla serve
 hopla serve --no-open
 hopla serve --host 0.0.0.0 --port 8080
+hopla serve --no-analysis
 ```
 
 The web interface imports legacy `.txt` and current YAML/JSON settings,

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -70,7 +70,7 @@ Details: [install.md](install.md).
   - `hopla convert LEGACY [OUTPUT]`
   - `hopla concordance FLOW1 FLOW2 [-r]`
   - `hopla transform FLOW1 FLOW2 MODE [OUTPUT]`
-  - `hopla serve [--host HOST] [--port PORT] [--no-open]`
+  - `hopla serve [--host HOST] [--port PORT] [--no-open] [--no-analysis]`
 - `vcf_file`, `out_dir`, and `cytoband_file` are CLI paths, not settings
   properties. Validate that supplied paths exist. `OUT_DIR` defaults to the
   current working directory; an omitted cytoband table is downloaded from UCSC.

--- a/docs/serve.md
+++ b/docs/serve.md
@@ -1,7 +1,8 @@
-# Local settings editor
+# Local web interface
 
-`hopla serve` starts a lightweight browser form for creating settings files.
-It is part of the Python package and requires no Node.js installation.
+`hopla serve` starts a lightweight browser interface for creating settings
+files and running analyses. It is part of the Python package and requires no
+Node.js installation.
 
 ```bash
 hopla serve
@@ -11,22 +12,42 @@ The default address is <http://127.0.0.1:8080/>. When invoked from an
 interactive terminal, Hopla opens that address in the default browser. Use
 `--no-open` to disable this behavior or `--port` to choose another port.
 
-The editor provides pedigree, analysis parameter, advanced, and validated YAML
-views. It can import:
+The interface provides pedigree, analysis parameter, advanced, validated YAML,
+and analysis views. It can import:
 
 - legacy Hopla `.txt` settings;
 - current `.yaml` and `.yml` settings;
 - current `.json` settings.
 
 Imports are limited to 1 MB. YAML downloads are validated against the packaged
-settings schema. The VCF, output-directory, and cytoband paths remain command
-line arguments and are never included in downloaded settings.
+settings schema.
+
+## Run an analysis
+
+Create a configuration in the form or import an existing configuration, then:
+
+1. Open the **Analysis** tab.
+2. Select a `.vcf`, `.vcf.gz`, or `.vcf.bgz` file from the local system.
+3. Select **Run analysis**.
+4. Wait for the status to report completion and download the HTML report.
+
+The browser streams the VCF to temporary storage on the machine running
+`hopla serve`. There is no configured upload-size limit, so available disk
+space must accommodate the input. The configuration, VCF, and generated report
+are removed when the server stops.
+
+Web analyses generate only the self-contained HTML report; they do not generate
+the Parquet or IGV sidecars written by the default `hopla run` command. Use the
+CLI when those exports, a persistent output directory, or a custom cytoband
+file are required. When the web interface needs the default hg38 cytobands, the
+server downloads them as it does for `hopla run` without `-c`.
 
 ## Network safety
 
-The server binds to loopback by default and has no authentication. It is
-intended to be started locally, used briefly, and stopped. Do not expose it to
-an untrusted network.
+The server binds to loopback by default and has no authentication. It accepts
+large genomic files and can start resource-intensive analyses. It is intended
+to be started locally, used briefly, and stopped. Do not expose it to an
+untrusted network.
 
 For a container or an explicitly managed reverse proxy, bind all interfaces:
 

--- a/docs/serve.md
+++ b/docs/serve.md
@@ -29,7 +29,14 @@ Create a configuration in the form or import an existing configuration, then:
 1. Open the **Analysis** tab.
 2. Select a `.vcf`, `.vcf.gz`, or `.vcf.bgz` file from the local system.
 3. Select **Run analysis**.
-4. Wait for the status to report completion and download the HTML report.
+4. Follow the running indicator and step log until the analysis reports
+   completion, then download the HTML report.
+
+While an analysis runs, the page lists each pipeline step with the seconds
+elapsed since the job started, the same major steps `hopla run` logs at `info`:
+receiving the VCF, loading it, applying filters, computing analyses, running
+Merlin when the pedigree allows it, and rendering the report. A failing step is
+appended to that log with its error.
 
 The browser streams the VCF to temporary storage on the machine running
 `hopla serve`. There is no configured upload-size limit, so available disk

--- a/docs/serve.md
+++ b/docs/serve.md
@@ -10,7 +10,8 @@ hopla serve
 
 The default address is <http://127.0.0.1:8080/>. When invoked from an
 interactive terminal, Hopla opens that address in the default browser. Use
-`--no-open` to disable this behavior or `--port` to choose another port.
+`--no-open` to disable this behavior or `--port` to choose another port. Use
+`--no-analysis` to serve the settings editor without the analysis runner.
 
 The interface provides pedigree, analysis parameter, advanced, validated YAML,
 and analysis views. It can import:
@@ -42,6 +43,11 @@ The browser streams the VCF to temporary storage on the machine running
 `hopla serve`. There is no configured upload-size limit, so available disk
 space must accommodate the input. The configuration, VCF, and generated report
 are removed when the server stops.
+
+Start the server with `--no-analysis` to offer settings editing only. The
+Analysis tab is then absent and the analysis endpoints are not registered, so an
+instance that should not read local VCFs or start runs cannot be driven into
+doing so.
 
 Web analyses generate only the self-contained HTML report; they do not generate
 the Parquet or IGV sidecars written by the default `hopla run` command. Use the

--- a/src/hopla/cli.py
+++ b/src/hopla/cli.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import logging
 import sys
-import tempfile
 import webbrowser
 from enum import StrEnum
 from pathlib import Path
@@ -16,19 +15,12 @@ import typer
 import uvicorn
 
 from hopla import __version__
-from hopla.analysis import build_analysis_tables, haplotype_concordance
 from hopla.convert import convert_settings
-from hopla.cytobands import chromosome_sizes, fetch_hg38, load_cytobands
-from hopla.export import export_igv_tracks, export_parquet
-from hopla.filters import apply_filter1, apply_filter2
 from hopla.flow import concordance as compare_flows
 from hopla.flow import transform as transform_flow
-from hopla.merlin import run_merlin
-from hopla.pedigree import add_ghosts, predict_genders
-from hopla.report import render_report
+from hopla.pipeline import run_analysis
 from hopla.serve import create_app
 from hopla.settings import load_settings
-from hopla.vcf import load_vcf, mask_male_x_heterozygotes
 
 app = typer.Typer(
     no_args_is_help=True,
@@ -125,35 +117,15 @@ def run_command(
     try:
         logging.info("Validating settings")
         settings = load_settings(settings_path)
-        logging.info("Loading VCF")
-        sites, matrix = load_vcf(vcf_path, settings.real_samples)
-        settings.genders = predict_genders(settings, sites, matrix)
-        mask_male_x_heterozygotes(sites, matrix, settings.sample_ids, settings.genders)
-        add_ghosts(settings)
-        logging.info("Applying filters")
-        filtered1 = apply_filter1(sites, matrix, settings)
-        filtered2 = apply_filter2(sites, matrix, filtered1, settings)
-        with tempfile.TemporaryDirectory(prefix="hopla-cytobands-") as temporary:
-            cytobands_file = cytoband_path or fetch_hg38(Path(temporary) / "cytoBand.txt")
-            cytobands = load_cytobands(cytobands_file)
-            sizes = chromosome_sizes(cytobands)
-            logging.info("Computing analyses")
-            tables = build_analysis_tables(sites, matrix, filtered1, filtered2, settings)
-            if settings.run_merlin:
-                logging.info("Running Merlin")
-                tables["haplotypes"] = run_merlin(
-                    out_dir / f"{settings.fam_id}-merlin", sites, matrix, filtered2, settings
-                )
-                if settings.concordance_table:
-                    tables["haplotype_concordance"] = haplotype_concordance(tables["haplotypes"])
-            if export_parquet_data:
-                logging.info("Writing portable Parquet exports")
-                export_parquet(out_dir / f"{settings.fam_id}-export", settings.fam_id, tables)
-            if export_bigwig:
-                logging.info("Writing IGV tracks")
-                export_igv_tracks(out_dir / f"{settings.fam_id}-export", tables, sizes)
-            report = out_dir / f"{settings.fam_id}-output.html"
-            render_report(report, settings, tables, matrix.samples, cytobands)
+        report = run_analysis(
+            settings,
+            vcf_path,
+            out_dir,
+            cytoband_path=cytoband_path,
+            export_parquet_data=export_parquet_data,
+            export_bigwig=export_bigwig,
+            progress=logging.info,
+        )
         typer.echo(report)
     except (OSError, ValueError, RuntimeError, pl.exceptions.PolarsError) as error:
         _runtime_error(error)

--- a/src/hopla/cli.py
+++ b/src/hopla/cli.py
@@ -150,13 +150,19 @@ def serve_command(
     open_browser: Annotated[
         bool, typer.Option("--open/--no-open", help="Open the editor in a local browser.")
     ] = True,
+    analysis: Annotated[
+        bool,
+        typer.Option("--analysis/--no-analysis", help="Offer the analysis runner."),
+    ] = True,
 ) -> None:
     """Serve the local Hopla settings editor."""
     url = f"http://{host}:{port}/"
     if open_browser and sys.stdout.isatty() and host in {"127.0.0.1", "localhost", "::1"}:
         Timer(0.5, webbrowser.open, args=(url,)).start()
     logging.info("Serving the settings editor at %s", url)
-    uvicorn.run(create_app(), host=host, port=port, log_level="warning")
+    if not analysis:
+        logging.info("Serving settings only; the analysis runner is disabled")
+    uvicorn.run(create_app(analysis=analysis), host=host, port=port, log_level="warning")
 
 
 @app.command("concordance")

--- a/src/hopla/pipeline.py
+++ b/src/hopla/pipeline.py
@@ -1,0 +1,68 @@
+"""Orchestrate the complete Hopla analysis pipeline."""
+
+from __future__ import annotations
+
+import tempfile
+from collections.abc import Callable
+from pathlib import Path
+
+from hopla.analysis import build_analysis_tables, haplotype_concordance
+from hopla.cytobands import chromosome_sizes, fetch_hg38, load_cytobands
+from hopla.export import export_igv_tracks, export_parquet
+from hopla.filters import apply_filter1, apply_filter2
+from hopla.merlin import run_merlin
+from hopla.pedigree import add_ghosts, predict_genders
+from hopla.report import render_report
+from hopla.settings import Settings
+from hopla.vcf import load_vcf, mask_male_x_heterozygotes
+
+ProgressCallback = Callable[[str], None]
+
+
+def run_analysis(
+    settings: Settings,
+    vcf_path: Path,
+    out_dir: Path,
+    *,
+    cytoband_path: Path | None = None,
+    export_parquet_data: bool = True,
+    export_bigwig: bool = True,
+    progress: ProgressCallback | None = None,
+) -> Path:
+    """Run an analysis and return the generated HTML report path."""
+
+    def update(message: str) -> None:
+        if progress is not None:
+            progress(message)
+
+    update("Loading VCF")
+    sites, matrix = load_vcf(vcf_path, settings.real_samples)
+    settings.genders = predict_genders(settings, sites, matrix)
+    mask_male_x_heterozygotes(sites, matrix, settings.sample_ids, settings.genders)
+    add_ghosts(settings)
+    update("Applying filters")
+    filtered1 = apply_filter1(sites, matrix, settings)
+    filtered2 = apply_filter2(sites, matrix, filtered1, settings)
+    with tempfile.TemporaryDirectory(prefix="hopla-cytobands-") as temporary:
+        cytobands_file = cytoband_path or fetch_hg38(Path(temporary) / "cytoBand.txt")
+        cytobands = load_cytobands(cytobands_file)
+        sizes = chromosome_sizes(cytobands)
+        update("Computing analyses")
+        tables = build_analysis_tables(sites, matrix, filtered1, filtered2, settings)
+        if settings.run_merlin:
+            update("Running Merlin")
+            tables["haplotypes"] = run_merlin(
+                out_dir / f"{settings.fam_id}-merlin", sites, matrix, filtered2, settings
+            )
+            if settings.concordance_table:
+                tables["haplotype_concordance"] = haplotype_concordance(tables["haplotypes"])
+        if export_parquet_data:
+            update("Writing portable Parquet exports")
+            export_parquet(out_dir / f"{settings.fam_id}-export", settings.fam_id, tables)
+        if export_bigwig:
+            update("Writing IGV tracks")
+            export_igv_tracks(out_dir / f"{settings.fam_id}-export", tables, sizes)
+        update("Rendering report")
+        report = out_dir / f"{settings.fam_id}-output.html"
+        render_report(report, settings, tables, matrix.samples, cytobands)
+    return report

--- a/src/hopla/serve.py
+++ b/src/hopla/serve.py
@@ -5,10 +5,11 @@ from __future__ import annotations
 import asyncio
 import re
 import tempfile
+import time
 import uuid
 from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import asynccontextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
@@ -40,6 +41,18 @@ class AnalysisJob:
     message: str = "Waiting for VCF upload"
     report: Path | None = None
     error: str | None = None
+    started: float = field(default_factory=time.monotonic)
+    log: list[dict[str, Any]] = field(default_factory=list)
+
+    @property
+    def elapsed(self) -> float:
+        """Return seconds since this job was created."""
+        return round(time.monotonic() - self.started, 1)
+
+    def record(self, message: str) -> None:
+        """Append one timestamped step to the job log."""
+        self.message = message
+        self.log.append({"seconds": self.elapsed, "message": message})
 
 
 class SecurityHeadersMiddleware(BaseHTTPMiddleware):
@@ -137,10 +150,6 @@ async def create_analysis(request: Request) -> JSONResponse:
 
 def _execute_analysis(job: AnalysisJob, vcf_path: Path) -> None:
     job.status = "running"
-
-    def progress(message: str) -> None:
-        job.message = message
-
     try:
         job.report = run_analysis(
             job.settings,
@@ -148,14 +157,14 @@ def _execute_analysis(job: AnalysisJob, vcf_path: Path) -> None:
             job.directory,
             export_parquet_data=False,
             export_bigwig=False,
-            progress=progress,
+            progress=job.record,
         )
         job.status = "completed"
-        job.message = "Analysis complete"
+        job.record("Analysis complete")
     except Exception as error:
         job.status = "failed"
-        job.message = "Analysis failed"
         job.error = str(error)
+        job.record(f"Analysis failed: {error}")
 
 
 async def upload_vcf(request: Request) -> JSONResponse:
@@ -176,10 +185,11 @@ async def upload_vcf(request: Request) -> JSONResponse:
         if size == 0:
             vcf_path.unlink(missing_ok=True)
             raise ValueError("The selected VCF is empty.")
+        job.record(f"Received {size / 1024 / 1024:.1f} MB VCF")
     except (OSError, ValueError) as error:
         job.status = "failed"
-        job.message = "VCF upload failed"
         job.error = str(error)
+        job.record(f"VCF upload failed: {error}")
         return JSONResponse({"error": str(error)}, status_code=422)
     task = asyncio.create_task(asyncio.to_thread(_execute_analysis, job, vcf_path))
     request.app.state.analysis_tasks.add(task)
@@ -196,6 +206,8 @@ async def analysis_status(request: Request) -> JSONResponse:
         "id": job.identifier,
         "status": job.status,
         "message": job.message,
+        "elapsed": job.elapsed,
+        "log": list(job.log),
     }
     if job.error is not None:
         result["error"] = job.error

--- a/src/hopla/serve.py
+++ b/src/hopla/serve.py
@@ -21,7 +21,7 @@ from starlette.staticfiles import StaticFiles
 from starlette.templating import Jinja2Templates
 
 from hopla.pipeline import run_analysis
-from hopla.settings import Settings
+from hopla.settings import Settings, validate_settings
 from hopla.ui.form import default_form, form_to_settings, import_config, render_yaml
 
 MAX_REQUEST_BYTES = 1024 * 1024 + 64 * 1024
@@ -112,7 +112,8 @@ async def download(request: Request) -> Response:
 
 def _job(request: Request) -> AnalysisJob | None:
     identifier = request.path_params["job_id"]
-    return request.app.state.analysis_jobs.get(identifier)
+    jobs: dict[str, AnalysisJob] = request.app.state.analysis_jobs
+    return jobs.get(identifier)
 
 
 async def create_analysis(request: Request) -> JSONResponse:
@@ -123,7 +124,7 @@ async def create_analysis(request: Request) -> JSONResponse:
         lower_name = filename.lower()
         if not lower_name.endswith((".vcf", ".vcf.gz", ".vcf.bgz")):
             raise ValueError("Choose a .vcf, .vcf.gz, or .vcf.bgz file.")
-        settings = form_to_settings(data["form"])
+        settings = validate_settings(form_to_settings(data["form"]))
         identifier = uuid.uuid4().hex
         directory = request.app.state.analysis_directory / identifier
         directory.mkdir()

--- a/src/hopla/serve.py
+++ b/src/hopla/serve.py
@@ -86,7 +86,11 @@ async def _json_body(request: Request) -> dict[str, Any]:
 
 async def editor(request: Request) -> HTMLResponse:
     """Render the settings editor."""
-    return templates.TemplateResponse(request, "index.html", {"initial_state": default_form()})
+    return templates.TemplateResponse(
+        request,
+        "index.html",
+        {"initial_state": default_form(), "analysis": request.app.state.analysis_enabled},
+    )
 
 
 async def preview(request: Request) -> JSONResponse:
@@ -241,22 +245,24 @@ async def _lifespan(app: Starlette) -> AsyncIterator[None]:
             await asyncio.gather(*app.state.analysis_tasks, return_exceptions=True)
 
 
-def create_app() -> Starlette:
-    """Create the local settings editor and analysis application."""
-    app = Starlette(
-        lifespan=_lifespan,
-        routes=[
-            Route("/", editor),
-            Route("/api/preview", preview, methods=["POST"]),
-            Route("/api/import", import_settings, methods=["POST"]),
-            Route("/api/download", download, methods=["POST"]),
+def create_app(*, analysis: bool = True) -> Starlette:
+    """Create the local settings editor, optionally without the analysis runner."""
+    routes: list[Route | Mount] = [
+        Route("/", editor),
+        Route("/api/preview", preview, methods=["POST"]),
+        Route("/api/import", import_settings, methods=["POST"]),
+        Route("/api/download", download, methods=["POST"]),
+    ]
+    if analysis:
+        routes += [
             Route("/api/analyses", create_analysis, methods=["POST"]),
             Route("/api/analyses/{job_id:str}/vcf", upload_vcf, methods=["PUT"]),
             Route("/api/analyses/{job_id:str}", analysis_status),
             Route("/api/analyses/{job_id:str}/report", analysis_report),
-            Mount("/static", StaticFiles(directory=UI_DIRECTORY / "static"), name="static"),
         ]
-    )
+    routes.append(Mount("/static", StaticFiles(directory=UI_DIRECTORY / "static"), name="static"))
+    app = Starlette(lifespan=_lifespan, routes=routes)
+    app.state.analysis_enabled = analysis
     app.add_middleware(SecurityHeadersMiddleware)
     return app
 

--- a/src/hopla/serve.py
+++ b/src/hopla/serve.py
@@ -2,24 +2,44 @@
 
 from __future__ import annotations
 
+import asyncio
 import re
+import tempfile
+import uuid
 from collections.abc import Awaitable, Callable
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, AsyncIterator
 
 from starlette.applications import Starlette
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
-from starlette.responses import HTMLResponse, JSONResponse, Response
+from starlette.responses import FileResponse, HTMLResponse, JSONResponse, Response
 from starlette.routing import Mount, Route
 from starlette.staticfiles import StaticFiles
 from starlette.templating import Jinja2Templates
 
-from hopla.ui.form import default_form, import_config, render_yaml
+from hopla.pipeline import run_analysis
+from hopla.settings import Settings
+from hopla.ui.form import default_form, form_to_settings, import_config, render_yaml
 
 MAX_REQUEST_BYTES = 1024 * 1024 + 64 * 1024
 UI_DIRECTORY = Path(__file__).parent / "ui"
 templates = Jinja2Templates(directory=UI_DIRECTORY / "templates")
+
+
+@dataclass
+class AnalysisJob:
+    """Track one temporary analysis launched from the editor."""
+
+    identifier: str
+    directory: Path
+    settings: Settings
+    status: str = "awaiting_upload"
+    message: str = "Waiting for VCF upload"
+    report: Path | None = None
+    error: str | None = None
 
 
 class SecurityHeadersMiddleware(BaseHTTPMiddleware):
@@ -90,14 +110,137 @@ async def download(request: Request) -> Response:
         return JSONResponse({"error": str(error)}, status_code=422)
 
 
+def _job(request: Request) -> AnalysisJob | None:
+    identifier = request.path_params["job_id"]
+    return request.app.state.analysis_jobs.get(identifier)
+
+
+async def create_analysis(request: Request) -> JSONResponse:
+    """Validate editor state and reserve temporary storage for an analysis."""
+    try:
+        data = await _json_body(request)
+        filename = str(data["vcf_name"])
+        lower_name = filename.lower()
+        if not lower_name.endswith((".vcf", ".vcf.gz", ".vcf.bgz")):
+            raise ValueError("Choose a .vcf, .vcf.gz, or .vcf.bgz file.")
+        settings = form_to_settings(data["form"])
+        identifier = uuid.uuid4().hex
+        directory = request.app.state.analysis_directory / identifier
+        directory.mkdir()
+        job = AnalysisJob(identifier, directory, settings)
+        request.app.state.analysis_jobs[identifier] = job
+        return JSONResponse({"id": identifier, "status": job.status}, status_code=201)
+    except (KeyError, TypeError, ValueError) as error:
+        return JSONResponse({"error": str(error)}, status_code=422)
+
+
+def _execute_analysis(job: AnalysisJob, vcf_path: Path) -> None:
+    job.status = "running"
+
+    def progress(message: str) -> None:
+        job.message = message
+
+    try:
+        job.report = run_analysis(
+            job.settings,
+            vcf_path,
+            job.directory,
+            export_parquet_data=False,
+            export_bigwig=False,
+            progress=progress,
+        )
+        job.status = "completed"
+        job.message = "Analysis complete"
+    except Exception as error:
+        job.status = "failed"
+        job.message = "Analysis failed"
+        job.error = str(error)
+
+
+async def upload_vcf(request: Request) -> JSONResponse:
+    """Stream an uploaded VCF into a job and launch its analysis."""
+    job = _job(request)
+    if job is None:
+        return JSONResponse({"error": "Analysis job not found."}, status_code=404)
+    if job.status != "awaiting_upload":
+        return JSONResponse({"error": "This analysis already received a VCF."}, status_code=409)
+    compressed = request.query_params.get("compressed") == "true"
+    vcf_path = job.directory / ("input.vcf.gz" if compressed else "input.vcf")
+    size = 0
+    try:
+        with vcf_path.open("wb") as handle:
+            async for chunk in request.stream():
+                size += len(chunk)
+                handle.write(chunk)
+        if size == 0:
+            vcf_path.unlink(missing_ok=True)
+            raise ValueError("The selected VCF is empty.")
+    except (OSError, ValueError) as error:
+        job.status = "failed"
+        job.message = "VCF upload failed"
+        job.error = str(error)
+        return JSONResponse({"error": str(error)}, status_code=422)
+    task = asyncio.create_task(asyncio.to_thread(_execute_analysis, job, vcf_path))
+    request.app.state.analysis_tasks.add(task)
+    task.add_done_callback(request.app.state.analysis_tasks.discard)
+    return JSONResponse({"id": job.identifier, "status": "running"}, status_code=202)
+
+
+async def analysis_status(request: Request) -> JSONResponse:
+    """Return the current state of a temporary analysis."""
+    job = _job(request)
+    if job is None:
+        return JSONResponse({"error": "Analysis job not found."}, status_code=404)
+    result: dict[str, Any] = {
+        "id": job.identifier,
+        "status": job.status,
+        "message": job.message,
+    }
+    if job.error is not None:
+        result["error"] = job.error
+    if job.status == "completed":
+        result["report_url"] = f"/api/analyses/{job.identifier}/report"
+    return JSONResponse(result)
+
+
+async def analysis_report(request: Request) -> Response:
+    """Download a completed analysis report."""
+    job = _job(request)
+    if job is None:
+        return JSONResponse({"error": "Analysis job not found."}, status_code=404)
+    if job.status != "completed" or job.report is None or not job.report.is_file():
+        return JSONResponse({"error": "The analysis report is not ready."}, status_code=409)
+    return FileResponse(
+        job.report,
+        media_type="text/html",
+        filename=job.report.name,
+    )
+
+
+@asynccontextmanager
+async def _lifespan(app: Starlette) -> AsyncIterator[None]:
+    with tempfile.TemporaryDirectory(prefix="hopla-web-") as temporary:
+        app.state.analysis_directory = Path(temporary)
+        app.state.analysis_jobs = {}
+        app.state.analysis_tasks = set()
+        yield
+        if app.state.analysis_tasks:
+            await asyncio.gather(*app.state.analysis_tasks, return_exceptions=True)
+
+
 def create_app() -> Starlette:
-    """Create the local settings-editor application."""
+    """Create the local settings editor and analysis application."""
     app = Starlette(
+        lifespan=_lifespan,
         routes=[
             Route("/", editor),
             Route("/api/preview", preview, methods=["POST"]),
             Route("/api/import", import_settings, methods=["POST"]),
             Route("/api/download", download, methods=["POST"]),
+            Route("/api/analyses", create_analysis, methods=["POST"]),
+            Route("/api/analyses/{job_id:str}/vcf", upload_vcf, methods=["PUT"]),
+            Route("/api/analyses/{job_id:str}", analysis_status),
+            Route("/api/analyses/{job_id:str}/report", analysis_report),
             Mount("/static", StaticFiles(directory=UI_DIRECTORY / "static"), name="static"),
         ]
     )

--- a/src/hopla/serve.py
+++ b/src/hopla/serve.py
@@ -6,11 +6,11 @@ import asyncio
 import re
 import tempfile
 import uuid
-from collections.abc import Awaitable, Callable
+from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, AsyncIterator
+from typing import Any
 
 from starlette.applications import Starlette
 from starlette.middleware.base import BaseHTTPMiddleware

--- a/src/hopla/ui/static/app.js
+++ b/src/hopla/ui/static/app.js
@@ -269,9 +269,22 @@ async function pollAnalysis(identifier) {
   }
 }
 
+function isVcfName(name) {
+  const lower = name.toLowerCase();
+  return lower.endsWith(".vcf") || lower.endsWith(".vcf.gz") || lower.endsWith(".vcf.bgz");
+}
+
 document.querySelector("#vcf-upload").addEventListener("change", (event) => {
   const file = event.target.files[0];
-  analysisState(file ? `Selected ${file.name}.` : "Select a VCF to begin.");
+  if (!file) {
+    analysisState("Select a VCF to begin.");
+    return;
+  }
+  if (!isVcfName(file.name)) {
+    analysisState("Choose a .vcf, .vcf.gz, or .vcf.bgz file.", true);
+    return;
+  }
+  analysisState(`Selected ${file.name}.`);
 });
 
 document.querySelector("#run-analysis").addEventListener("click", async () => {
@@ -280,6 +293,10 @@ document.querySelector("#run-analysis").addEventListener("click", async () => {
   const file = picker.files[0];
   if (!file) {
     analysisState("Choose a VCF before running the analysis.", true);
+    return;
+  }
+  if (!isVcfName(file.name)) {
+    analysisState("Choose a .vcf, .vcf.gz, or .vcf.bgz file.", true);
     return;
   }
   readFields();

--- a/src/hopla/ui/static/app.js
+++ b/src/hopla/ui/static/app.js
@@ -239,8 +239,23 @@ function analysisState(text, error = false) {
 
 function finishAnalysis() {
   clearTimeout(analysisTimer);
+  document.querySelector("#analysis-progress").hidden = true;
   document.querySelector("#run-analysis").disabled = false;
   document.querySelector("#vcf-upload").disabled = false;
+}
+
+function renderLog(entries) {
+  const list = document.querySelector("#analysis-log");
+  list.replaceChildren(...entries.map((entry) => {
+    const item = document.createElement("li");
+    const seconds = document.createElement("span");
+    seconds.className = "log-time";
+    seconds.textContent = `${entry.seconds.toFixed(1)} s`;
+    item.append(seconds, entry.message);
+    return item;
+  }));
+  list.hidden = entries.length === 0;
+  list.scrollTop = list.scrollHeight;
 }
 
 async function pollAnalysis(identifier) {
@@ -248,8 +263,9 @@ async function pollAnalysis(identifier) {
     const response = await fetch(`/api/analyses/${identifier}`);
     if (!response.ok) throw new Error(await responseError(response));
     const result = await response.json();
+    renderLog(result.log || []);
     if (result.status === "completed") {
-      analysisState("Analysis complete. Download the HTML report below.");
+      analysisState(`Analysis complete in ${result.elapsed} s. Download the report below.`);
       const link = document.querySelector("#report-download");
       link.href = result.report_url;
       link.hidden = false;
@@ -261,7 +277,7 @@ async function pollAnalysis(identifier) {
       finishAnalysis();
       return;
     }
-    analysisState(result.message || "Analysis is running.");
+    analysisState(`${result.message || "Analysis is running"} (${result.elapsed} s)`);
     analysisTimer = setTimeout(() => pollAnalysis(identifier), 1000);
   } catch (error) {
     analysisState(error.message, true);
@@ -304,6 +320,8 @@ document.querySelector("#run-analysis").addEventListener("click", async () => {
   button.disabled = true;
   picker.disabled = true;
   document.querySelector("#report-download").hidden = true;
+  document.querySelector("#analysis-progress").hidden = false;
+  renderLog([]);
   try {
     analysisState("Validating configuration.");
     const created = await api("/api/analyses", {form: state, vcf_name: file.name});

--- a/src/hopla/ui/static/app.js
+++ b/src/hopla/ui/static/app.js
@@ -290,7 +290,7 @@ function isVcfName(name) {
   return lower.endsWith(".vcf") || lower.endsWith(".vcf.gz") || lower.endsWith(".vcf.bgz");
 }
 
-document.querySelector("#vcf-upload").addEventListener("change", (event) => {
+document.querySelector("#vcf-upload")?.addEventListener("change", (event) => {
   const file = event.target.files[0];
   if (!file) {
     analysisState("Select a VCF to begin.");
@@ -303,7 +303,7 @@ document.querySelector("#vcf-upload").addEventListener("change", (event) => {
   analysisState(`Selected ${file.name}.`);
 });
 
-document.querySelector("#run-analysis").addEventListener("click", async () => {
+document.querySelector("#run-analysis")?.addEventListener("click", async () => {
   const picker = document.querySelector("#vcf-upload");
   const button = document.querySelector("#run-analysis");
   const file = picker.files[0];

--- a/src/hopla/ui/static/app.js
+++ b/src/hopla/ui/static/app.js
@@ -27,6 +27,7 @@ const placeholders = {
   mother: "U2",
 };
 let previewTimer;
+let analysisTimer;
 
 function message(text, error = false) {
   const node = document.querySelector("#message");
@@ -143,6 +144,15 @@ async function api(path, payload) {
   return response;
 }
 
+async function responseError(response) {
+  try {
+    const result = await response.json();
+    return result.error || "The server could not process this request.";
+  } catch {
+    return "The server could not process this request.";
+  }
+}
+
 async function updatePreview() {
   readFields();
   try {
@@ -221,8 +231,84 @@ document.querySelector("#download").addEventListener("click", async () => {
   }
 });
 
+function analysisState(text, error = false) {
+  const node = document.querySelector("#analysis-status");
+  node.textContent = text;
+  node.classList.toggle("error", error);
+}
+
+function finishAnalysis() {
+  clearTimeout(analysisTimer);
+  document.querySelector("#run-analysis").disabled = false;
+  document.querySelector("#vcf-upload").disabled = false;
+}
+
+async function pollAnalysis(identifier) {
+  try {
+    const response = await fetch(`/api/analyses/${identifier}`);
+    if (!response.ok) throw new Error(await responseError(response));
+    const result = await response.json();
+    if (result.status === "completed") {
+      analysisState("Analysis complete. Download the HTML report below.");
+      const link = document.querySelector("#report-download");
+      link.href = result.report_url;
+      link.hidden = false;
+      finishAnalysis();
+      return;
+    }
+    if (result.status === "failed") {
+      analysisState(result.error || "Analysis failed.", true);
+      finishAnalysis();
+      return;
+    }
+    analysisState(result.message || "Analysis is running.");
+    analysisTimer = setTimeout(() => pollAnalysis(identifier), 1000);
+  } catch (error) {
+    analysisState(error.message, true);
+    finishAnalysis();
+  }
+}
+
+document.querySelector("#vcf-upload").addEventListener("change", (event) => {
+  const file = event.target.files[0];
+  analysisState(file ? `Selected ${file.name}.` : "Select a VCF to begin.");
+});
+
+document.querySelector("#run-analysis").addEventListener("click", async () => {
+  const picker = document.querySelector("#vcf-upload");
+  const button = document.querySelector("#run-analysis");
+  const file = picker.files[0];
+  if (!file) {
+    analysisState("Choose a VCF before running the analysis.", true);
+    return;
+  }
+  readFields();
+  clearTimeout(analysisTimer);
+  button.disabled = true;
+  picker.disabled = true;
+  document.querySelector("#report-download").hidden = true;
+  try {
+    analysisState("Validating configuration.");
+    const created = await api("/api/analyses", {form: state, vcf_name: file.name});
+    const job = await created.json();
+    analysisState(`Uploading ${file.name}.`);
+    const compressed = file.name.toLowerCase().endsWith(".gz")
+      || file.name.toLowerCase().endsWith(".bgz");
+    const uploaded = await fetch(
+      `/api/analyses/${job.id}/vcf?compressed=${compressed}`,
+      {method: "PUT", headers: {"Content-Type": "application/octet-stream"}, body: file},
+    );
+    if (!uploaded.ok) throw new Error(await responseError(uploaded));
+    analysisState("Analysis is starting.");
+    await pollAnalysis(job.id);
+  } catch (error) {
+    analysisState(error.message, true);
+    finishAnalysis();
+  }
+});
+
 document.querySelectorAll("input, select, textarea").forEach((input) => {
-  if (input.id !== "config-upload") input.addEventListener("input", schedulePreview);
+  if (input.type !== "file") input.addEventListener("input", schedulePreview);
 });
 fillFields();
 renderMembers();

--- a/src/hopla/ui/static/style.css
+++ b/src/hopla/ui/static/style.css
@@ -25,6 +25,7 @@ button, .button {
   padding: .55rem .8rem;
 }
 button:hover, .button:hover { filter: brightness(1.12); }
+button:disabled { cursor: wait; opacity: .6; }
 .upload { display: inline-block; }
 .upload input { display: none; }
 .tabs { display: flex; gap: .25rem; border-bottom: 2px solid var(--accent); }
@@ -45,9 +46,14 @@ input[type=checkbox] { width: auto; }
 .section-heading h2, .section-heading h3 { margin: 0; }
 .danger { background: #a12828; padding: .3rem .55rem; }
 pre { min-height: 20rem; overflow: auto; border: 1px solid var(--border); padding: 1rem; background: var(--surface); }
-#message.error { color: #c22; font-weight: 600; }
+.error { color: #c22; font-weight: 600; }
 .hint { border-left: .25rem solid var(--accent); padding-left: .75rem; }
+.analysis-controls { display: flex; align-items: end; gap: 1rem; }
+.analysis-controls label { flex: 1; }
+[hidden] { display: none !important; }
 @media (max-width: 650px) {
   .fields { grid-template-columns: 1fr; }
   .wide { grid-column: auto; }
+  .tabs { flex-wrap: wrap; }
+  .analysis-controls { align-items: stretch; flex-direction: column; }
 }

--- a/src/hopla/ui/static/style.css
+++ b/src/hopla/ui/static/style.css
@@ -37,7 +37,7 @@ button:disabled { cursor: wait; opacity: .6; }
 .member-card { padding: 1rem; border: 1px solid var(--border); border-radius: .5rem; background: var(--surface); }
 .member-card > label, .fields > label { display: flex; flex-direction: column; gap: .25rem; margin: .55rem 0; }
 input, select, textarea { background: Canvas; color: CanvasText; padding: .45rem; width: 100%; }
-fieldset { display: grid; grid-template-columns: 1fr 1fr; gap: .3rem; border: 1px solid var(--border); }
+fieldset { display: grid; grid-template-columns: repeat(auto-fit, minmax(8rem, 1fr)); gap: .3rem; border: 1px solid var(--border); }
 fieldset label, .fields label:has(input[type=checkbox]) { display: flex; align-items: center; gap: .4rem; }
 input[type=checkbox] { width: auto; }
 .fields { display: grid; grid-template-columns: 1fr 1fr; gap: 0 1.5rem; }

--- a/src/hopla/ui/static/style.css
+++ b/src/hopla/ui/static/style.css
@@ -50,6 +50,20 @@ pre { min-height: 20rem; overflow: auto; border: 1px solid var(--border); paddin
 .hint { border-left: .25rem solid var(--accent); padding-left: .75rem; }
 .analysis-controls { display: flex; align-items: end; gap: 1rem; }
 .analysis-controls label { flex: 1; }
+#analysis-progress { width: 100%; height: .5rem; }
+.log {
+  max-height: 14rem;
+  overflow: auto;
+  margin: .75rem 0;
+  padding: .75rem 1rem;
+  border: 1px solid var(--border);
+  border-radius: .35rem;
+  background: var(--surface);
+  font-family: ui-monospace, monospace;
+  list-style: none;
+}
+.log li { display: flex; gap: .75rem; padding: .1rem 0; }
+.log-time { flex: 0 0 5rem; text-align: right; opacity: .7; }
 [hidden] { display: none !important; }
 @media (max-width: 650px) {
   .fields { grid-template-columns: 1fr; }

--- a/src/hopla/ui/templates/index.html
+++ b/src/hopla/ui/templates/index.html
@@ -95,7 +95,8 @@
       </p>
       <div class="analysis-controls">
         <label>Family VCF
-          <input id="vcf-upload" type="file" accept=".vcf,.vcf.gz,.vcf.bgz">
+          <input id="vcf-upload" type="file"
+                 accept=".vcf,.vcf.gz,.vcf.bgz,.gz,.bgz,text/plain,application/gzip">
         </label>
         <button type="button" id="run-analysis">Run analysis</button>
       </div>

--- a/src/hopla/ui/templates/index.html
+++ b/src/hopla/ui/templates/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
-  <title>Hopla analysis</title>
+  <title>Hopla settings editor and analysis</title>
   <link rel="icon" href="/static/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="/static/style.css">
   <script src="/static/app.js" defer></script>

--- a/src/hopla/ui/templates/index.html
+++ b/src/hopla/ui/templates/index.html
@@ -11,7 +11,10 @@
 <body>
   <header>
     <h1>Hopla</h1>
-    <p>Build, validate, and run a family analysis.</p>
+    <p>
+      {% if analysis %}Build, validate, and run a family analysis.
+      {% else %}Build and validate a settings file for <code>hopla run</code>.{% endif %}
+    </p>
     <label class="upload button">Import configuration
       <input id="config-upload" type="file" accept=".txt,.yaml,.yml,.json">
     </label>
@@ -24,7 +27,7 @@
       <button type="button" data-tab="parameters">Parameters</button>
       <button type="button" data-tab="advanced">Advanced</button>
       <button type="button" data-tab="config">Config</button>
-      <button type="button" data-tab="analysis">Analysis</button>
+      {% if analysis %}<button type="button" data-tab="analysis">Analysis</button>{% endif %}
     </nav>
 
     <section id="pedigree" class="panel active">
@@ -87,6 +90,7 @@
       <pre id="yaml-preview"></pre>
     </section>
 
+    {% if analysis %}
     <section id="analysis" class="panel">
       <h2>Run analysis</h2>
       <p>
@@ -109,6 +113,7 @@
       <ol id="analysis-log" class="log" hidden></ol>
       <a id="report-download" class="button" href="#" download hidden>Download HTML report</a>
     </section>
+    {% endif %}
   </main>
 
   <template id="member-template">

--- a/src/hopla/ui/templates/index.html
+++ b/src/hopla/ui/templates/index.html
@@ -105,6 +105,8 @@
         Web runs generate the HTML report only.
       </p>
       <p id="analysis-status" role="status" aria-live="polite">Select a VCF to begin.</p>
+      <progress id="analysis-progress" aria-label="Analysis running" hidden></progress>
+      <ol id="analysis-log" class="log" hidden></ol>
       <a id="report-download" class="button" href="#" download hidden>Download HTML report</a>
     </section>
   </main>

--- a/src/hopla/ui/templates/index.html
+++ b/src/hopla/ui/templates/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
-  <title>Hopla settings editor</title>
+  <title>Hopla analysis</title>
   <link rel="icon" href="/static/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="/static/style.css">
   <script src="/static/app.js" defer></script>
@@ -11,7 +11,7 @@
 <body>
   <header>
     <h1>Hopla</h1>
-    <p>Build and validate a settings file for <code>hopla run</code>.</p>
+    <p>Build, validate, and run a family analysis.</p>
     <label class="upload button">Import configuration
       <input id="config-upload" type="file" accept=".txt,.yaml,.yml,.json">
     </label>
@@ -24,6 +24,7 @@
       <button type="button" data-tab="parameters">Parameters</button>
       <button type="button" data-tab="advanced">Advanced</button>
       <button type="button" data-tab="config">Config</button>
+      <button type="button" data-tab="analysis">Analysis</button>
     </nav>
 
     <section id="pedigree" class="panel active">
@@ -61,7 +62,7 @@
         <label><input id="keep_chromosomes_only" type="checkbox"> Keep chromosomes only</label>
         <label><input id="keep_regions_only" type="checkbox"> Keep regions only</label>
       </div>
-      <p class="hint">VCF, output-directory, and cytoband paths belong on the command line.</p>
+      <p class="hint">Select the input VCF on the Analysis tab.</p>
     </section>
 
     <section id="advanced" class="panel">
@@ -84,6 +85,26 @@
         <button type="button" id="download">Download YAML</button>
       </div>
       <pre id="yaml-preview"></pre>
+    </section>
+
+    <section id="analysis" class="panel">
+      <h2>Run analysis</h2>
+      <p>
+        Hopla uses the current validated configuration. Imported configurations and changes made
+        in this editor are handled identically.
+      </p>
+      <div class="analysis-controls">
+        <label>Family VCF
+          <input id="vcf-upload" type="file" accept=".vcf,.vcf.gz,.vcf.bgz">
+        </label>
+        <button type="button" id="run-analysis">Run analysis</button>
+      </div>
+      <p class="hint">
+        The VCF and generated report are stored temporarily and removed when this server stops.
+        Web runs generate the HTML report only.
+      </p>
+      <p id="analysis-status" role="status" aria-live="polite">Select a VCF to begin.</p>
+      <a id="report-download" class="button" href="#" download hidden>Download HTML report</a>
     </section>
   </main>
 

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -6,9 +6,11 @@ import time
 from pathlib import Path
 from typing import Any
 
+import pytest
 import yaml
 from starlette.testclient import TestClient
 
+from hopla.pipeline import ProgressCallback
 from hopla.serve import create_app
 from hopla.settings import Settings, validate_settings
 from hopla.ui.form import default_form, import_config, render_yaml, settings_to_form
@@ -137,7 +139,7 @@ def _wait_for_status(
 
 
 def test_stream_vcf_run_and_download_report(
-    monkeypatch: Any,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Stream a VCF, run with editor settings, and download its report."""
 
@@ -145,13 +147,19 @@ def test_stream_vcf_run_and_download_report(
         settings: Settings,
         vcf_path: Path,
         out_dir: Path,
-        **options: Any,
+        *,
+        cytoband_path: Path | None = None,
+        export_parquet_data: bool = True,
+        export_bigwig: bool = True,
+        progress: ProgressCallback | None = None,
     ) -> Path:
+        del cytoband_path
         assert settings.sample_ids == ["FATHER"]
         assert vcf_path.read_bytes() == b"VCF data"
-        assert options["export_parquet_data"] is False
-        assert options["export_bigwig"] is False
-        options["progress"]("Computing analyses")
+        assert export_parquet_data is False
+        assert export_bigwig is False
+        assert progress is not None
+        progress("Computing analyses")
         report = out_dir / f"{settings.fam_id}-output.html"
         report.write_text("<html>report</html>", encoding="utf-8")
         return report
@@ -209,10 +217,28 @@ def test_analysis_rejects_invalid_input_and_empty_vcf() -> None:
         assert status["error"] == "The selected VCF is empty."
 
 
-def test_analysis_surfaces_pipeline_failure(monkeypatch: Any) -> None:
+def test_analysis_surfaces_pipeline_failure(monkeypatch: pytest.MonkeyPatch) -> None:
     """Expose a pipeline failure through job status without a report."""
 
-    def fail_run(*args: Any, **kwargs: Any) -> Path:
+    def fail_run(
+        settings: Settings,
+        vcf_path: Path,
+        out_dir: Path,
+        *,
+        cytoband_path: Path | None = None,
+        export_parquet_data: bool = True,
+        export_bigwig: bool = True,
+        progress: ProgressCallback | None = None,
+    ) -> Path:
+        del (
+            settings,
+            vcf_path,
+            out_dir,
+            cytoband_path,
+            export_parquet_data,
+            export_bigwig,
+            progress,
+        )
         raise ValueError("VCF does not contain sample FATHER")
 
     monkeypatch.setattr("hopla.serve.run_analysis", fail_run)

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -43,6 +43,23 @@ def test_editor_and_validated_download() -> None:
         assert 'filename="famID.yaml"' in download.headers["content-disposition"]
 
 
+def test_no_analysis_hides_tab_and_endpoints() -> None:
+    """Serve settings only when the analysis runner is disabled."""
+    with TestClient(create_app(analysis=False)) as client:
+        page = client.get("/")
+        assert page.status_code == 200
+        assert 'data-tab="analysis"' not in page.text
+        assert 'id="vcf-upload"' not in page.text
+        assert client.post("/api/preview", json={"form": _single_sample_form()}).status_code == 200
+
+        created = client.post(
+            "/api/analyses",
+            json={"form": _single_sample_form(), "vcf_name": "family.vcf"},
+        )
+        assert created.status_code == 404
+        assert client.get("/api/analyses/missing").status_code == 404
+
+
 def test_add_sibling_state_and_validation_error() -> None:
     """Accept repeatable member state and surface invalid values."""
     state = _single_sample_form()

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -180,6 +180,13 @@ def test_stream_vcf_run_and_download_report(
         status = _wait_for_status(client, identifier, "completed")
         assert status["message"] == "Analysis complete"
         assert status["report_url"].endswith(f"/{identifier}/report")
+        messages = [entry["message"] for entry in status["log"]]
+        assert messages == [
+            "Received 0.0 MB VCF",
+            "Computing analyses",
+            "Analysis complete",
+        ]
+        assert all(entry["seconds"] >= 0 for entry in status["log"])
 
         report = client.get(status["report_url"])
         assert report.status_code == 200
@@ -215,6 +222,9 @@ def test_analysis_rejects_invalid_input_and_empty_vcf() -> None:
         status = client.get(f"/api/analyses/{identifier}").json()
         assert status["status"] == "failed"
         assert status["error"] == "The selected VCF is empty."
+        assert status["log"][-1]["message"] == (
+            "VCF upload failed: The selected VCF is empty."
+        )
 
 
 def test_analysis_surfaces_pipeline_failure(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -251,6 +261,9 @@ def test_analysis_surfaces_pipeline_failure(monkeypatch: pytest.MonkeyPatch) -> 
         client.put(f"/api/analyses/{identifier}/vcf", content=b"bad data")
         status = _wait_for_status(client, identifier, "failed")
         assert status["error"] == "VCF does not contain sample FATHER"
+        assert status["log"][-1]["message"] == (
+            "Analysis failed: VCF does not contain sample FATHER"
+        )
         report = client.get(f"/api/analyses/{identifier}/report")
         assert report.status_code == 409
 

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -2,13 +2,15 @@
 
 from __future__ import annotations
 
+import time
 from pathlib import Path
+from typing import Any
 
 import yaml
 from starlette.testclient import TestClient
 
 from hopla.serve import create_app
-from hopla.settings import validate_settings
+from hopla.settings import Settings, validate_settings
 from hopla.ui.form import default_form, import_config, render_yaml, settings_to_form
 
 
@@ -121,4 +123,108 @@ def test_settings_to_form_preserves_unedited_schema_fields() -> None:
     generated = yaml.safe_load(render_yaml(state))
     assert generated["run_merlin"] is False
     assert generated["dot_factor"] == 3
+
+
+def _wait_for_status(
+    client: TestClient, identifier: str, expected: str
+) -> dict[str, Any]:
+    for _ in range(100):
+        result = client.get(f"/api/analyses/{identifier}").json()
+        if result["status"] == expected:
+            return result
+        time.sleep(0.01)
+    raise AssertionError(f"Analysis did not reach {expected}")
+
+
+def test_stream_vcf_run_and_download_report(
+    monkeypatch: Any,
+) -> None:
+    """Stream a VCF, run with editor settings, and download its report."""
+
+    def fake_run(
+        settings: Settings,
+        vcf_path: Path,
+        out_dir: Path,
+        **options: Any,
+    ) -> Path:
+        assert settings.sample_ids == ["FATHER"]
+        assert vcf_path.read_bytes() == b"VCF data"
+        assert options["export_parquet_data"] is False
+        assert options["export_bigwig"] is False
+        options["progress"]("Computing analyses")
+        report = out_dir / f"{settings.fam_id}-output.html"
+        report.write_text("<html>report</html>", encoding="utf-8")
+        return report
+
+    monkeypatch.setattr("hopla.serve.run_analysis", fake_run)
+    with TestClient(create_app()) as client:
+        created = client.post(
+            "/api/analyses",
+            json={"form": _single_sample_form(), "vcf_name": "family.vcf"},
+        )
+        assert created.status_code == 201
+        identifier = created.json()["id"]
+        uploaded = client.put(
+            f"/api/analyses/{identifier}/vcf?compressed=false",
+            content=b"VCF data",
+        )
+        assert uploaded.status_code == 202
+        status = _wait_for_status(client, identifier, "completed")
+        assert status["message"] == "Analysis complete"
+        assert status["report_url"].endswith(f"/{identifier}/report")
+
+        report = client.get(status["report_url"])
+        assert report.status_code == 200
+        assert report.text == "<html>report</html>"
+        assert 'filename="famID-output.html"' in report.headers["content-disposition"]
+
+
+def test_analysis_rejects_invalid_input_and_empty_vcf() -> None:
+    """Reject invalid configuration, extensions, and empty uploads."""
+    invalid = _single_sample_form()
+    invalid["af_hard_limit"] = 2
+    with TestClient(create_app()) as client:
+        bad_settings = client.post(
+            "/api/analyses",
+            json={"form": invalid, "vcf_name": "family.vcf"},
+        )
+        assert bad_settings.status_code == 422
+        assert "maximum of 1" in bad_settings.json()["error"]
+
+        bad_extension = client.post(
+            "/api/analyses",
+            json={"form": _single_sample_form(), "vcf_name": "family.txt"},
+        )
+        assert bad_extension.status_code == 422
+
+        created = client.post(
+            "/api/analyses",
+            json={"form": _single_sample_form(), "vcf_name": "family.vcf.gz"},
+        )
+        identifier = created.json()["id"]
+        empty = client.put(f"/api/analyses/{identifier}/vcf?compressed=true", content=b"")
+        assert empty.status_code == 422
+        status = client.get(f"/api/analyses/{identifier}").json()
+        assert status["status"] == "failed"
+        assert status["error"] == "The selected VCF is empty."
+
+
+def test_analysis_surfaces_pipeline_failure(monkeypatch: Any) -> None:
+    """Expose a pipeline failure through job status without a report."""
+
+    def fail_run(*args: Any, **kwargs: Any) -> Path:
+        raise ValueError("VCF does not contain sample FATHER")
+
+    monkeypatch.setattr("hopla.serve.run_analysis", fail_run)
+    with TestClient(create_app()) as client:
+        created = client.post(
+            "/api/analyses",
+            json={"form": _single_sample_form(), "vcf_name": "family.vcf"},
+        )
+        identifier = created.json()["id"]
+        client.put(f"/api/analyses/{identifier}/vcf", content=b"bad data")
+        status = _wait_for_status(client, identifier, "failed")
+        assert status["error"] == "VCF does not contain sample FATHER"
+        report = client.get(f"/api/analyses/{identifier}/report")
+        assert report.status_code == 409
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- extract reusable analysis pipeline orchestration from the CLI
- add temporary streamed VCF uploads and asynchronous web analysis jobs
- add analysis controls, a live step log with elapsed timings, failure handling, and report download to the settings editor
- accept compressed VCFs in the file picker and validate the selected name in the browser
- add `hopla serve --no-analysis`, which hides the Analysis tab and leaves the analysis endpoints unregistered
- keep the pedigree "Include in" checkboxes inside their member card when several individuals are added
- document the temporary browser workflow and add endpoint regressions

## Verification
- `pixi install --locked`
- `pixi run -e dev lint-py`
- `pixi run -e dev test-py` (27 passed)
- `pixi run -e dev python -m pip wheel --no-deps . -w /tmp/hopla-wheel`
- Browser: successful new-config VCF analysis and report download/open; config import; missing VCF and invalid config errors; cross-tab state; desktop and mobile layouts
- Compressed input: `.vcf.gz` selected in the file dialog and analyzed end to end through the running server
- Progress: step log streamed live during a 12 s run (`Received 0.7 MB VCF`, `Loading VCF`, `Applying filters`, `Computing analyses`, `Rendering report`, `Analysis complete`), confirmed both through the status API and in the browser, where the running indicator, growing log, and ticking elapsed counter were observed mid-run and cleared on completion
- Flag: `--no-analysis` serves no Analysis tab or VCF picker and returns 404 from `/api/analyses`, while the editor tabs, preview, and YAML download still work
- Layout: no overflow of the "Include in" box with four grandparents, four siblings, and four embryos at desktop, 800 px, and 400 px widths
- Docker image build skipped because Docker is not installed in the environment

[pedigree-layout-and-no-analysis-flag.mp4](https://cursor.com/agents/bc-50b76999-7d00-46ac-80f7-bbec0d48cd48/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpedigree-layout-and-no-analysis-flag.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-50b76999-7d00-46ac-80f7-bbec0d48cd48?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-50b76999-7d00-46ac-80f7-bbec0d48cd48&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

