### PR TITLE
Replace parallel pedigree arrays with structured family members

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,7 @@ The package manual is [docs/README.md](docs/README.md).
   - `hopla transform FLOW1 FLOW2 MODE [OUTPUT]`
   - `hopla serve [--host HOST] [--port PORT] [--no-open] [--no-analysis]`
 - `vcf_file`, `out_dir`, and `cytoband_file` are CLI paths, not settings properties. Validate that supplied paths exist. `OUT_DIR` defaults to the current working directory; an omitted cytoband table is downloaded from UCSC.
-- Default `run` also writes `{fam_id}-export/` Parquet and IGV sidecars unless disabled with `--no-export-parquet` / `--no-export-bigwig`.
+- Default `run` also writes `{family.id}-export/` Parquet and IGV sidecars unless disabled with `--no-export-parquet` / `--no-export-bigwig`.
 - `convert` maps the legacy `key=value` settings format to schema-validated YAML.
 - Return zero for help, version, and successful commands; return status 2 for invalid usage and status 1 for runtime failures.
 - Global options are `-h`, `-V` (not `-v`), and `-L LEVEL` (`error`, `warn`, `info`, `debug`; default `info`). Use `--` to terminate option parsing. Options must precede operands. `concordance` accepts `-r` for relative comparison. `run` also accepts `-L` before its operands.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ subtools, including historical notes from the predecessor R analysis pipeline.
 
 - Replaced order-aligned pedigree arrays in generated YAML/JSON with structured
   `family.id` and `family.members` objects. Existing parallel-array settings
-  are remapped when loaded.
+  are remapped when loaded; the engine also uses member-by-ID lookup directly.
 - Renamed legacy `genders` values to member `sex` values during conversion and import.
 - `info` is multiline free text rather than a list of lines. The settings editor uses one text box instead of Disease / Inheritance / Sequencing note fields.
 - Import, convert, and `hopla run` ignore unsupported keys after a warning instead of failing. Generated YAML omits unused compatibility keys.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ subtools, including historical notes from the predecessor R analysis pipeline.
 - Added columnar VCF loading with cyvcf2 into shared site tables and sample-by-site NumPy matrices.
 - Added filter 1 / filter 2 masks, variant statistics, ADO/ADI, BAF, Mendelian errors, parent mapping, and Merlin haplotyping with neighbourhood voting and short-segment correction.
 - Added a self-contained offline HTML report that inlines `plotly.js`, gzip-compresses columnar payloads, and draws SVG panels lazily on scroll.
-- Added default `{fam_id}-export/` Parquet tables plus BigWig / BED / SEG / `igv-session.xml` IGV desktop sidecars, with `--no-export-parquet` and `--no-export-bigwig` toggles.
+- Added default `{family.id}-export/` Parquet tables plus BigWig / BED / SEG / `igv-session.xml` IGV desktop sidecars, with `--no-export-parquet` and `--no-export-bigwig` toggles.
 - Added `hopla serve`, a loopback-only-by-default Starlette and Jinja settings editor packaged with the Python wheel.
 - Added schema-validated YAML preview/download and legacy `.txt`, YAML, and JSON imports with pedigree reconstruction.
 - Added browser-driven analysis to `hopla serve`: it runs the current configuration with an uploaded VCF and returns a temporary self-contained HTML report, with a live step log and a `--no-analysis` flag that serves settings editing only.
@@ -21,7 +21,10 @@ subtools, including historical notes from the predecessor R analysis pipeline.
 
 ### Changed
 
-- Renamed the `genders` setting to `sexes`. Legacy files still use `genders`; convert and import remap it.
+- Replaced order-aligned pedigree arrays in generated YAML/JSON with structured
+  `family.id` and `family.members` objects. Existing parallel-array settings
+  are remapped when loaded.
+- Renamed legacy `genders` values to member `sex` values during conversion and import.
 - `info` is multiline free text rather than a list of lines. The settings editor uses one text box instead of Disease / Inheritance / Sequencing note fields.
 - Import, convert, and `hopla run` ignore unsupported keys after a warning instead of failing. Generated YAML omits unused compatibility keys.
 - Flattened the repository so the installable Python package lives at the root (`src/hopla/`, `tests/`, `docs/`, `example/`) instead of the `hopla-r/` / `hopla-ui/` monorepo.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ pixi install --locked
 pixi run hopla run example/settings.yaml path/to/family.vcf.gz
 ```
 
-By default `hopla run` also writes `{fam_id}-export/` with Parquet tables and
+By default `hopla run` also writes `{family.id}-export/` with Parquet tables and
 IGV desktop tracks. See [exports.md](docs/exports.md). Example settings and a
 legacy conversion fixture are in [`example/`](example/).
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -48,7 +48,7 @@ pixi run hopla run example/settings.yaml path/to/family.vcf.gz
 
 The command validates settings before reading the VCF and writes a compact,
 offline HTML report. By default it also writes portable Parquet tables and IGV
-desktop tracks under `{fam_id}-export/`. Merlin 1.1.2 remains an optional
+desktop tracks under `{family.id}-export/`. Merlin 1.1.2 remains an optional
 external dependency for haplotyping. Example settings live in
 [`example/`](../example/).
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -35,9 +35,9 @@ There is no runtime fallback to another package tree.
 
 The Python engine is explicit and columnar:
 
-1. `settings.py` validates the structured `family.members` YAML/JSON model,
-   expands it to the engine's pedigree arrays, and derives defaults before VCF
-   loading.
+1. `settings.py` validates the structured `family.members` YAML/JSON model and
+   derives pedigree defaults before VCF loading. Engine modules resolve
+   parents and sex directly from family members by ID.
 2. `vcf.py` streams selected biallelic SNVs with cyvcf2 into one `SiteTable`
    and compact sample-by-site NumPy matrices.
 3. `filters.py`, `analysis.py`, and `merlin.py` operate on masks and matrices;

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -35,8 +35,9 @@ There is no runtime fallback to another package tree.
 
 The Python engine is explicit and columnar:
 
-1. `settings.py` validates YAML/JSON against the Hopla schema and derives
-   pedigree defaults before VCF loading.
+1. `settings.py` validates the structured `family.members` YAML/JSON model,
+   expands it to the engine's pedigree arrays, and derives defaults before VCF
+   loading.
 2. `vcf.py` streams selected biallelic SNVs with cyvcf2 into one `SiteTable`
    and compact sample-by-site NumPy matrices.
 3. `filters.py`, `analysis.py`, and `merlin.py` operate on masks and matrices;

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -36,7 +36,7 @@ hopla [-hV] [-L LEVEL] serve [--host HOST] [--port PORT]
   [hg38 `cytoBand.txt.gz`](https://hgdownload.soe.ucsc.edu/goldenPath/hg38/database/cytoBand.txt.gz)
   into a temporary directory for that run.
 - `--export-parquet` / `--no-export-parquet` controls writing portable Parquet
-  tables under `{fam_id}-export/` (default: on).
+  tables under `{family.id}-export/` (default: on).
 - `--export-bigwig` / `--no-export-bigwig` controls writing BigWig, BED, SEG,
   and `igv-session.xml` under the same export directory (default: on). Details:
   [exports.md](exports.md).

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -73,7 +73,7 @@ Details: [install.md](install.md).
 - `vcf_file`, `out_dir`, and `cytoband_file` are CLI paths, not settings
   properties. Validate that supplied paths exist. `OUT_DIR` defaults to the
   current working directory; an omitted cytoband table is downloaded from UCSC.
-- Default `run` also writes `{fam_id}-export/` Parquet and IGV sidecars unless
+- Default `run` also writes `{family.id}-export/` Parquet and IGV sidecars unless
   disabled with `--no-export-parquet` / `--no-export-bigwig`.
 - `convert` maps the legacy `key=value` settings format to schema-validated
   YAML.

--- a/docs/exports.md
+++ b/docs/exports.md
@@ -1,6 +1,6 @@
 # Portable analysis exports
 
-`hopla run` writes `{fam_id}-export/` by default. Use
+`hopla run` writes `{family.id}-export/` by default. Use
 `--no-export-parquet` when only the HTML report is needed.
 
 Each visualized dataset is stored in its own Apache Parquet file with zstd

--- a/docs/igvjs-evaluation.md
+++ b/docs/igvjs-evaluation.md
@@ -47,7 +47,7 @@ categorical data as BED, copy-number segments as SEG, and a relative-path
 existing BAM/CRAM tracks without copying those sensitive, large files into the
 Hopla report.
 
-This keeps the HTML a single offline file. The `{fam_id}-export/` directory is
+This keeps the HTML a single offline file. The `{family.id}-export/` directory is
 an optional interoperability export, not a required multi-file web
 application.
 

--- a/docs/output.md
+++ b/docs/output.md
@@ -1,9 +1,9 @@
 # HTML output
 
-The analysis writes an interactive HTML file (`{fam_id}-output.html`). Hovering,
+The analysis writes an interactive HTML file (`{family.id}-output.html`). Hovering,
 dragging, and related Plotly controls manipulate the figures, and raw data can
 often be inspected. By default the same run also writes portable Parquet tables
-and IGV desktop tracks under `{fam_id}-export/`; see [exports.md](exports.md).
+and IGV desktop tracks under `{family.id}-export/`; see [exports.md](exports.md).
 
 The report is always a single offline document: the offline `plotly.js` bundle
 is inlined once, analysis tables are serialized column-wise and gzip-compressed
@@ -15,7 +15,7 @@ number of samples and plotted variants. Restrict `baf_ids`, enable
 `limit_baf_to_p` or `limit_pm_to_p`, and use the haplotyping region controls when
 further reduction is needed.
 
-Output names use `fam_id` (default `hopla`). Haplotyping colours are relative
+Output names use `family.id` (default `hopla`). Haplotyping colours are relative
 within a family: the same haplotype colour is not stable across different HTML
 files.
 
@@ -38,10 +38,10 @@ preserved. The text is not interpreted as key-value pairs.
 ## Family tree
 
 If two or more samples are provided, the family structure is shown as defined
-by `sample_ids`, `father_ids`, and `mother_ids`. Annotations follow
+by `family.members` and each member's `father` and `mother`. Annotations follow
 `reference_ids`, `carrier_ids`, `affected_ids`, and `nonaffected_ids` (those
 labels are reused throughout the HTML). Squares are males and circles are
-females, from `sexes`, or from `x_cutoff` / `y_cutoff` when sex is
+females, from each member's `sex`, or from `x_cutoff` / `y_cutoff` when sex is
 unknown. The pedigree is an inline SVG.
 
 ## Filter 0: single nucleotide variants
@@ -122,7 +122,7 @@ ADO/ADI is not calculated.
 
 ### Haplotyping by Merlin
 
-Merlin runs when more than one real sample is in `sample_ids`, `run_merlin` is
+Merlin runs when more than one real sample is in `family.members`, `run_merlin` is
 `true`, and the `merlin` / `minx` executables are on `$PATH`. There is no
 haplotyping when the family structure does not allow it (no reference sample
 means no breakpoints in the haplotyping strands).

--- a/docs/serve.md
+++ b/docs/serve.md
@@ -22,8 +22,9 @@ and analysis views. It can import:
 
 Imports are limited to 1 MB. Unsupported keys are ignored after a warning.
 YAML downloads are validated against the packaged settings schema and omit
-unused compatibility keys. The editor maps pedigree `Sex` onto `sexes` and
-stores family notes as a single multiline `info` string.
+unused compatibility keys. The editor writes each pedigree card as an entry in
+`family.members`, including its `sex`, and stores family notes as a single
+multiline `info` string.
 
 ## Run an analysis
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -48,10 +48,12 @@ A complete example is [`example/settings.yaml`](../example/settings.yaml).
   contain exactly two.
 
 ```yaml
-sample_ids: [sample_C, sample_B, sample_A]
-father_ids: [null, null, sample_C]
-mother_ids: [null, null, sample_B]
-sexes: [M, F, null]
+family:
+  id: example
+  members:
+    - {id: sample_C, sex: M}
+    - {id: sample_B, sex: F}
+    - {id: sample_A, father: sample_C, mother: sample_B}
 run_merlin: true
 regions:
   - chr7:117480025-117668665
@@ -62,35 +64,42 @@ info: |
 
 Equivalent JSON is accepted. Types and constraints are identical.
 
+Files using the former parallel `sample_ids`, `father_ids`, `mother_ids`,
+`sexes`, and `fam_id` properties are remapped when loaded. New and generated
+configurations use `family`; if both representations are present, `family`
+wins and the parallel properties are ignored with a warning.
+
 ## Mandatory settings
 
-- **`sample_ids`** (`string` array) Sample IDs to analyze. They must be present
-  in the VCF given on the CLI. Example: `[sample_C, sample_B, sample_A]`. Missing
-  pedigree members can be added with unknown IDs `U1`, `U2`, …, which is useful
-  to define uncle/niece/… relations by reusing those IDs in `father_ids` and
-  `mother_ids`. Ghost IDs matching `U[0-9]+` are not loaded from the VCF.
+- **`family`** (`object`) Family description containing a `members` array and
+  optional `id`.
+- **`family.members`** (`object` array) Samples and pedigree members. Every
+  member requires a unique, non-empty `id`. VCF-backed IDs must be present in
+  the VCF given on the CLI. Missing pedigree members can use IDs `U1`, `U2`, …;
+  IDs matching `U[0-9]+` are pedigree ghosts and are not loaded from the VCF.
+  A member can name its `father` and `mother` by ID, independent of where either
+  member appears in the array.
 
 The VCF file is the `VCF` operand to `hopla run`. The output directory is
 optional `-o OUT_DIR` (default `$PWD`) and the cytoband table is optional
 `-c CYTOBAND`. Supplied paths are checked for existence before analysis starts.
 The engine does not create a missing output directory.
 
-When more than one sample is listed, at least one of `father_ids` or
-`mother_ids` must contain a non-null parent reference.
+When more than one member is listed, at least one member must name a non-null
+`father` or `mother`.
 
 ## Optional settings
 
 ### Important optional settings
 
-- **`father_ids`** (`string | null` array, no default) Father sample IDs. Use
-  `null` when not available. Order matches `sample_ids`. Example:
-  `[null, null, sample_C]`.
-- **`mother_ids`** (`string | null` array, no default) Mother sample IDs. Use
-  `null` when not available. Order matches `sample_ids`. Example:
-  `[null, null, sample_B]`.
-- **`sexes`** (`M` / `F` / `null` array, no default) Sample sex. Use
-  `null` when not available; the model then predicts sex (see `x_cutoff` and
-  `y_cutoff`). Order matches `sample_ids`. Example: `[M, F, null]`.
+- **`family.id`** (`string`, default `hopla`) Family ID used in output file
+  names. Non-word characters are replaced with `.` after load.
+- **`family.members[].father`** / **`family.members[].mother`**
+  (`string | null`, default `null`) Parent IDs. A named parent must be another
+  member of the same family.
+- **`family.members[].sex`** (`M` / `F` / `null`, default `null`) Sample sex.
+  When omitted or `null`, the model predicts sex (see `x_cutoff` and
+  `y_cutoff`).
 - **`run_merlin`** (`boolean`, default `true`) Whether Merlin haplotyping should
   run. The Merlin executables directory (`path/to/merlin-1.1.2/executables`)
   must be on `$PATH`, which is automatic with the pixi default environment.
@@ -100,22 +109,21 @@ When more than one sample is listed, at least one of `father_ids` or
 The cytoband table is a CLI path (`-c CYTOBAND`), not a settings property. See
 [cli.md](cli.md).
 
-If `father_ids`, `mother_ids`, or `sexes` are omitted, they are filled with
-`null` for every entry in `sample_ids`.
+Omitted `father`, `mother`, and `sex` properties are treated as `null`.
 
 ### Important optional variant inclusion settings: filter 1
 
 - Every sample in **`dp_hard_limit_ids`** (`string` array, default all but last
-  line children/embryos from `sample_ids`) should have variants with coverage
+  line children/embryos from `family.members`) should have variants with coverage
   of at least **`dp_hard_limit`** (`number ≥ 0`, default `10`). This is a hard
   filter: variants that do not comply are removed from all samples.
 - At least one sample in **`af_hard_limit_ids`** (`string` array, default all
-  but last line children/embryos from `sample_ids`) should have variants with
+  but last line children/embryos from `family.members`) should have variants with
   an allele fraction of at least **`af_hard_limit`** (`number` in `[0, 1)`,
   default `0`). This is a hard filter: variants that do not comply are removed
   from all samples.
 - Variants from samples in **`dp_soft_limit_ids`** (`string` array, default last
-  line children/embryos from `sample_ids`) should have coverage of at least
+  line children/embryos from `family.members`) should have coverage of at least
   **`dp_soft_limit`** (`number ≥ 0`, default `10`). This is a soft filter:
   variants that do not comply are removed from the given samples only.
 
@@ -209,8 +217,6 @@ raw uncorrected genotypes remain available on hover.
 
 ### Remaining features
 
-- **`fam_id`** (`string`, default `hopla`) Family ID, used in output file names.
-  Non-word characters are replaced with `.` after load.
 - **`x_cutoff`** (`number`, default `1.5`) X chromosome copy-number cutoff for
   sex prediction (one copy assumed in males, two in females).
 - **`y_cutoff`** (`number`, default `0.6`) Y chromosome copy-number cutoff for
@@ -266,17 +272,17 @@ Conversion rules:
 - The converted document is validated before it is written.
 - Unsupported keys are omitted after a warning. Missing mandatory fields fail
   the conversion.
-- Legacy `genders` is written as `sexes`. The `start.info` … `end.info` block
-  becomes a multiline `info` string.
+- Legacy parallel pedigree fields are written as structured `family.members`.
+  The `start.info` … `end.info` block becomes a multiline `info` string.
 
 | Legacy key | YAML / JSON key |
 | --- | --- |
 | `vcf.file` | *(CLI `VCF` operand; omitted from YAML)* |
 | `out.dir` | *(CLI `-o OUT_DIR`; omitted from YAML)* |
-| `sample.ids` | `sample_ids` |
-| `father.ids` | `father_ids` |
-| `mother.ids` | `mother_ids` |
-| `genders` | `sexes` |
+| `sample.ids` | `family.members[].id` |
+| `father.ids` | `family.members[].father` |
+| `mother.ids` | `family.members[].mother` |
+| `genders` | `family.members[].sex` |
 | `run.merlin` | `run_merlin` |
 | `cytoband.file` | *(CLI `-c CYTOBAND`; omitted from YAML)* |
 | `dp.hard.limit.ids` | `dp_hard_limit_ids` |
@@ -302,7 +308,7 @@ Conversion rules:
 | `keep.chromosomes.only` | `keep_chromosomes_only` |
 | `keep.regions.only` | `keep_regions_only` |
 | `concordance.table` | `concordance_table` |
-| `fam.id` / `fam.ID` | `fam_id` |
+| `fam.id` / `fam.ID` | `family.id` |
 | `X.cutoff` | `x_cutoff` |
 | `Y.cutoff` | `y_cutoff` |
 | `window.size` | `window_size` |

--- a/example/settings.yaml
+++ b/example/settings.yaml
@@ -1,9 +1,13 @@
 # Complete Hopla YAML settings example.
-sample_ids: [DNA052961, U1, DNA052959, DNA052960, DNA052963, DNA052966]
-
-father_ids: [null, null, U1, null, DNA052960, DNA052960]
-mother_ids: [null, null, DNA052961, null, DNA052959, DNA052959]
-sexes: [F, M, F, M, null, null]
+family:
+  id: hopla
+  members:
+    - {id: DNA052961, sex: F}
+    - {id: U1, sex: M}
+    - {id: DNA052959, father: U1, mother: DNA052961, sex: F}
+    - {id: DNA052960, sex: M}
+    - {id: DNA052963, father: DNA052960, mother: DNA052959}
+    - {id: DNA052966, father: DNA052960, mother: DNA052959}
 run_merlin: true
 # Pass a cytoband table with -c; omit it to download hg38 cytoBand.txt.gz from UCSC.
 

--- a/src/hopla/analysis.py
+++ b/src/hopla/analysis.py
@@ -222,9 +222,9 @@ def ado_adi(
     rows: list[dict[str, object]] = []
     for level, calls in ((0, matrix.gt), (1, filtered1.gt)):
         for child in matrix.samples:
-            pedigree_index = settings.sample_ids.index(child)
-            father = settings.father_ids[pedigree_index]
-            mother = settings.mother_ids[pedigree_index]
+            member = settings.family.member(child)
+            father = member.father
+            mother = member.mother
             if father not in matrix.sample_index or mother not in matrix.sample_index:
                 continue
             child_gt = calls[matrix.sample_index[child]]
@@ -331,9 +331,9 @@ def mendelian_table(
     starts, keys = _window_ids(sites, filtered.site_mask, settings.window_size)
     frames: list[pl.DataFrame] = []
     for child in matrix.samples:
-        pedigree = settings.sample_ids.index(child)
-        father = settings.father_ids[pedigree]
-        mother = settings.mother_ids[pedigree]
+        member = settings.family.member(child)
+        father = member.father
+        mother = member.mother
         child_gt = filtered.gt[matrix.sample_index[child]]
         trio = np.zeros(child_gt.size, dtype=np.int8)
         fat = np.zeros(child_gt.size, dtype=np.int8)
@@ -378,9 +378,9 @@ def parent_mapping_table(
     source = np.flatnonzero(filtered.site_mask)
     rows: list[pl.DataFrame] = []
     for child in matrix.samples:
-        pedigree = settings.sample_ids.index(child)
-        father = settings.father_ids[pedigree]
-        mother = settings.mother_ids[pedigree]
+        member = settings.family.member(child)
+        father = member.father
+        mother = member.mother
         child_gt = filtered.gt[matrix.sample_index[child]]
         masks: list[tuple[str, np.ndarray]] = []
         if father in matrix.sample_index:

--- a/src/hopla/convert.py
+++ b/src/hopla/convert.py
@@ -9,7 +9,13 @@ from typing import Any
 import yaml
 from jsonschema import Draft7Validator
 
-from hopla.settings import prepare_settings_mapping, schema_path, schema_properties
+from hopla.settings import (
+    LEGACY_FAMILY_KEYS,
+    family_from_parallel_arrays,
+    prepare_settings_mapping,
+    schema_path,
+    schema_properties,
+)
 
 
 def parse_legacy_text(text: str) -> dict[str, str | list[str]]:
@@ -82,23 +88,36 @@ def _coerce(value: str | list[str], specification: dict[str, Any]) -> Any:
     return value
 
 
+def _csv_tokens(value: str | list[str], *, nullable: bool) -> list[Any]:
+    tokens = value if isinstance(value, list) else value.split(",")
+    return [
+        None if str(token).strip() in {"", "NA"} and nullable else str(token).strip()
+        for token in tokens
+    ]
+
+
 def _convert_mapping(raw: dict[str, str | list[str]]) -> dict[str, Any]:
     """Coerce a parsed legacy mapping and drop unsupported keys."""
     schema = json.loads(schema_path().read_text(encoding="utf-8"))
     properties = schema_properties()
-    nullable_lists = {"father_ids", "mother_ids", "sexes", "genders"}
-    list_keys = nullable_lists | {"sample_ids"}
     converted: dict[str, Any] = {}
+    if "sample_ids" in raw:
+        sexes = raw.get("sexes", raw.get("genders"))
+        converted["family"] = family_from_parallel_arrays(
+            _csv_tokens(raw["sample_ids"], nullable=False),
+            father_ids=(
+                _csv_tokens(raw["father_ids"], nullable=True) if "father_ids" in raw else None
+            ),
+            mother_ids=(
+                _csv_tokens(raw["mother_ids"], nullable=True) if "mother_ids" in raw else None
+            ),
+            sexes=_csv_tokens(sexes, nullable=True) if sexes is not None else None,
+            fam_id=raw.get("fam_id"),
+        )
     for key, value in raw.items():
-        if key in list_keys:
-            if isinstance(value, list):
-                converted[key] = value
-            else:
-                converted[key] = [
-                    None if token.strip() in {"", "NA"} and key in nullable_lists else token.strip()
-                    for token in value.split(",")
-                ]
-        elif key in properties:
+        if key in LEGACY_FAMILY_KEYS:
+            continue
+        if key in properties:
             converted[key] = _coerce(value, properties[key])
         else:
             converted[key] = value

--- a/src/hopla/convert.py
+++ b/src/hopla/convert.py
@@ -101,9 +101,10 @@ def _convert_mapping(raw: dict[str, str | list[str]]) -> dict[str, Any]:
     schema = json.loads(schema_path().read_text(encoding="utf-8"))
     properties = schema_properties()
     converted: dict[str, Any] = {}
+    family: dict[str, Any] | None = None
     if "sample_ids" in raw:
         sexes = raw.get("sexes", raw.get("genders"))
-        converted["family"] = family_from_parallel_arrays(
+        family = family_from_parallel_arrays(
             _csv_tokens(raw["sample_ids"], nullable=False),
             father_ids=(
                 _csv_tokens(raw["father_ids"], nullable=True) if "father_ids" in raw else None
@@ -121,6 +122,8 @@ def _convert_mapping(raw: dict[str, str | list[str]]) -> dict[str, Any]:
             converted[key] = _coerce(value, properties[key])
         else:
             converted[key] = value
+    if family is not None:
+        converted["family"] = family
     prepared, _ignored = prepare_settings_mapping(converted)
     errors = list(Draft7Validator(schema).iter_errors(prepared))
     if errors:

--- a/src/hopla/convert.py
+++ b/src/hopla/convert.py
@@ -86,27 +86,18 @@ def _convert_mapping(raw: dict[str, str | list[str]]) -> dict[str, Any]:
     """Coerce a parsed legacy mapping and drop unsupported keys."""
     schema = json.loads(schema_path().read_text(encoding="utf-8"))
     properties = schema_properties()
-    legacy_arrays = {
-        "sample_ids": False,
-        "father_ids": True,
-        "mother_ids": True,
-        "sexes": True,
-        "genders": True,
-    }
+    nullable_lists = {"father_ids", "mother_ids", "sexes", "genders"}
+    list_keys = nullable_lists | {"sample_ids"}
     converted: dict[str, Any] = {}
     for key, value in raw.items():
-        if key in legacy_arrays:
+        if key in list_keys:
             if isinstance(value, list):
                 converted[key] = value
             else:
                 converted[key] = [
-                    None
-                    if token.strip() in {"", "NA"} and legacy_arrays[key]
-                    else token.strip()
+                    None if token.strip() in {"", "NA"} and key in nullable_lists else token.strip()
                     for token in value.split(",")
                 ]
-        elif key == "fam_id":
-            converted[key] = value
         elif key in properties:
             converted[key] = _coerce(value, properties[key])
         else:

--- a/src/hopla/convert.py
+++ b/src/hopla/convert.py
@@ -86,16 +86,38 @@ def _convert_mapping(raw: dict[str, str | list[str]]) -> dict[str, Any]:
     """Coerce a parsed legacy mapping and drop unsupported keys."""
     schema = json.loads(schema_path().read_text(encoding="utf-8"))
     properties = schema_properties()
-    prepared, _ignored = prepare_settings_mapping(raw)
-    converted = {
-        key: _coerce(prepared[key], properties[key]) for key in properties if key in prepared
+    legacy_arrays = {
+        "sample_ids": False,
+        "father_ids": True,
+        "mother_ids": True,
+        "sexes": True,
+        "genders": True,
     }
-    errors = list(Draft7Validator(schema).iter_errors(converted))
+    converted: dict[str, Any] = {}
+    for key, value in raw.items():
+        if key in legacy_arrays:
+            if isinstance(value, list):
+                converted[key] = value
+            else:
+                converted[key] = [
+                    None
+                    if token.strip() in {"", "NA"} and legacy_arrays[key]
+                    else token.strip()
+                    for token in value.split(",")
+                ]
+        elif key == "fam_id":
+            converted[key] = value
+        elif key in properties:
+            converted[key] = _coerce(value, properties[key])
+        else:
+            converted[key] = value
+    prepared, _ignored = prepare_settings_mapping(converted)
+    errors = list(Draft7Validator(schema).iter_errors(prepared))
     if errors:
         raise ValueError(
             "Converted settings failed validation:\n" + "\n".join(error.message for error in errors)
         )
-    return converted
+    return prepared
 
 
 def convert_settings(legacy: Path, output: Path | None = None) -> Path:

--- a/src/hopla/filters.py
+++ b/src/hopla/filters.py
@@ -56,10 +56,7 @@ def apply_filter2(
         informative = ((gt[first] == 1) & np.isin(gt[second], (0, 2))) | (
             (gt[second] == 1) & np.isin(gt[first], (0, 2))
         )
-        sexes = [
-            settings.sexes[settings.sample_ids.index(sample)]
-            for sample in settings.keep_informative_ids
-        ]
+        sexes = [settings.family.member(sample).sex for sample in settings.keep_informative_ids]
         if sexes == ["M", "M"]:
             informative[selected_chrom == CHROMOSOME_CODES["chrX"]] = True
         site_keep &= informative

--- a/src/hopla/merlin.py
+++ b/src/hopla/merlin.py
@@ -110,10 +110,11 @@ def _write_inputs(
             for index in selected_indices
         )
         pedigree_rows = []
-        for pedigree_index, sample in enumerate(settings.sample_ids):
-            sex = "1" if settings.sexes[pedigree_index] == "M" else "2"
-            father = settings.father_ids[pedigree_index] or "0"
-            mother = settings.mother_ids[pedigree_index] or "0"
+        for member in settings.family.members:
+            sample = member.id
+            sex = "1" if member.sex == "M" else "2"
+            father = member.father or "0"
+            mother = member.mother or "0"
             calls = (
                 [alleles[matrix.sample_index[sample]][index] for index in selected_indices]
                 if sample in matrix.sample_index

--- a/src/hopla/pedigree.py
+++ b/src/hopla/pedigree.py
@@ -7,12 +7,13 @@ from html import escape
 import numpy as np
 
 from hopla.models import CHROMOSOME_CODES, GenotypeMatrix, SiteTable
-from hopla.settings import Settings, Sex
+from hopla.settings import FamilyMember, Settings, Sex
 
 
 def predict_sexes(settings: Settings, sites: SiteTable, matrix: GenotypeMatrix) -> list[Sex]:
     """Fill unknown sexes from pedigree roles and chromosome depth ratios."""
-    result = list(settings.sexes)
+    fathers = {member.father for member in settings.family.members if member.father}
+    mothers = {member.mother for member in settings.family.members if member.mother}
     autosomal = sites.chrom <= 22
     x_mask = sites.chrom == CHROMOSOME_CODES["chrX"]
     y_mask = (
@@ -44,13 +45,13 @@ def predict_sexes(settings: Settings, sites: SiteTable, matrix: GenotypeMatrix) 
         where=autosomal_mean > 0,
     )
     for sample in matrix.samples:
-        index = settings.sample_ids.index(sample)
-        if result[index] is not None:
+        member = settings.family.member(sample)
+        if member.sex is not None:
             continue
-        if sample in settings.mother_ids:
-            result[index] = "F"
-        elif sample in settings.father_ids:
-            result[index] = "M"
+        if sample in mothers:
+            member.sex = "F"
+        elif sample in fathers:
+            member.sex = "M"
         else:
             matrix_index = matrix.sample_index[sample]
             x_value, y_value = x_copies[matrix_index], y_copies[matrix_index]
@@ -62,41 +63,37 @@ def predict_sexes(settings: Settings, sites: SiteTable, matrix: GenotypeMatrix) 
             )
             if x_sex is None and y_sex is None:
                 raise ValueError(f"Could not predict sex for sample {sample}.")
-            result[index] = y_sex if y_sex is not None else x_sex
+            member.sex = y_sex if y_sex is not None else x_sex
     unresolved = [
-        sample for sample, sex in zip(settings.sample_ids, result, strict=True) if sex is None
+        member.id for member in settings.family.members if member.sex is None
     ]
     if unresolved:
         raise ValueError(f"Sex must be provided for ghost sample(s): {', '.join(unresolved)}")
-    return result
+    return [member.sex for member in settings.family.members]
 
 
 def add_ghosts(settings: Settings) -> Settings:
     """Add missing single parents as sequential U identifiers."""
     existing = [
         int(sample[1:])
-        for sample in settings.sample_ids
+        for sample in settings.family.member_ids
         if sample[:1].upper() == "U" and sample[1:].isdigit()
     ]
     counter = max(existing, default=0)
-    original_count = len(settings.sample_ids)
-    for index in range(original_count):
-        missing_father = settings.father_ids[index] is None
-        missing_mother = settings.mother_ids[index] is None
+    for member in list(settings.family.members):
+        missing_father = member.father is None
+        missing_mother = member.mother is None
         if missing_father == missing_mother:
             continue
         counter += 1
         ghost = f"U{counter}"
         if missing_father:
-            settings.father_ids[index] = ghost
+            member.father = ghost
             sex: Sex = "M"
         else:
-            settings.mother_ids[index] = ghost
+            member.mother = ghost
             sex = "F"
-        settings.sample_ids.append(ghost)
-        settings.father_ids.append(None)
-        settings.mother_ids.append(None)
-        settings.sexes.append(sex)
+        settings.family.add_member(FamilyMember(id=ghost, sex=sex))
     return settings
 
 
@@ -121,8 +118,8 @@ def sample_label(settings: Settings, sample: str) -> str:
 
 def _generations(settings: Settings) -> list[int]:
     """Place samples one row below their deepest parent and partners on a shared row."""
-    index = {sample: position for position, sample in enumerate(settings.sample_ids)}
-    depth = [0] * len(settings.sample_ids)
+    index = {sample: position for position, sample in enumerate(settings.family.member_ids)}
+    depth = [0] * len(settings.family.members)
     couples = [
         (index[father], index[mother])
         for father, mother in _sibships(settings)
@@ -130,8 +127,8 @@ def _generations(settings: Settings) -> list[int]:
     ]
     for _ in range(2 * len(depth) + 2):
         changed = False
-        for position in range(len(depth)):
-            for parent in (settings.father_ids[position], settings.mother_ids[position]):
+        for position, member in enumerate(settings.family.members):
+            for parent in (member.father, member.mother):
                 if parent in index and depth[position] <= depth[index[parent]]:
                     depth[position] = depth[index[parent]] + 1
                     changed = True
@@ -147,14 +144,14 @@ def _generations(settings: Settings) -> list[int]:
 
 def _sibships(settings: Settings) -> dict[tuple[str, str], list[str]]:
     """Group samples by the parent pair that produced them."""
-    known = set(settings.sample_ids)
+    known = set(settings.family.member_ids)
     families: dict[tuple[str, str], list[str]] = {}
-    for position, sample in enumerate(settings.sample_ids):
-        father = settings.father_ids[position]
-        mother = settings.mother_ids[position]
+    for member in settings.family.members:
+        father = member.father
+        mother = member.mother
         pair = (father if father in known else "", mother if mother in known else "")
         if any(pair):
-            families.setdefault(pair, []).append(sample)
+            families.setdefault(pair, []).append(member.id)
     return families
 
 
@@ -175,14 +172,14 @@ def _layout(settings: Settings) -> tuple[dict[str, float], list[int]]:
         for member, other in ((father, mother), (mother, father))
     }
     # Columns are wide enough that neighbouring labels never touch.
-    widest = max(len(sample_label(settings, sample)) for sample in settings.sample_ids)
+    widest = max(len(sample_label(settings, sample)) for sample in settings.family.member_ids)
     column = max(_COLUMN, 7.4 * widest + 18)
     rows: dict[int, list[str]] = {}
     positions: dict[str, float] = {}
     for generation in sorted(set(depth)):
         members = [
             sample
-            for position, sample in enumerate(settings.sample_ids)
+            for position, sample in enumerate(settings.family.member_ids)
             if depth[position] == generation
         ]
         ordered: list[str] = []
@@ -202,7 +199,7 @@ def _layout(settings: Settings) -> tuple[dict[str, float], list[int]]:
         placed = [positions[sample] for sample in samples]
         return (min(placed) + max(placed)) / 2
 
-    index = {sample: position for position, sample in enumerate(settings.sample_ids)}
+    index = {sample: position for position, sample in enumerate(settings.family.member_ids)}
     for _ in range(6):
         for (father, mother), children in families.items():
             parents = [parent for parent in (father, mother) if parent]
@@ -213,8 +210,8 @@ def _layout(settings: Settings) -> tuple[dict[str, float], list[int]]:
         for (father, mother), children in families.items():
             parents = [parent for parent in (father, mother) if parent]
             if any(
-                settings.father_ids[index[parent]] in index
-                or settings.mother_ids[index[parent]] in index
+                settings.family.member(parent).father in index
+                or settings.family.member(parent).mother in index
                 for parent in parents
             ):
                 continue
@@ -230,7 +227,7 @@ def pedigree_svg(settings: Settings) -> str:
     """Render the family as a conventional pedigree chart."""
     positions, depth = _layout(settings)
     families = _sibships(settings)
-    index = {sample: position for position, sample in enumerate(settings.sample_ids)}
+    index = {sample: position for position, sample in enumerate(settings.family.member_ids)}
     rows = {sample: _MARGIN + depth[index[sample]] * _GENERATION for sample in positions}
     half = _SYMBOL / 2
 
@@ -260,7 +257,7 @@ def pedigree_svg(settings: Settings) -> str:
     symbols: list[str] = []
     for sample, x in positions.items():
         y = rows[sample]
-        sex = settings.sexes[index[sample]]
+        sex = settings.family.member(sample).sex
         affected = sample in settings.affected_ids
         fill = "#334155" if affected else "#ffffff"
         if sex == "M":

--- a/src/hopla/pedigree.py
+++ b/src/hopla/pedigree.py
@@ -10,7 +10,7 @@ from hopla.models import CHROMOSOME_CODES, GenotypeMatrix, SiteTable
 from hopla.settings import FamilyMember, Settings, Sex
 
 
-def predict_sexes(settings: Settings, sites: SiteTable, matrix: GenotypeMatrix) -> list[Sex]:
+def predict_sexes(settings: Settings, sites: SiteTable, matrix: GenotypeMatrix) -> None:
     """Fill unknown sexes from pedigree roles and chromosome depth ratios."""
     fathers = {member.father for member in settings.family.members if member.father}
     mothers = {member.mother for member in settings.family.members if member.mother}
@@ -69,7 +69,6 @@ def predict_sexes(settings: Settings, sites: SiteTable, matrix: GenotypeMatrix) 
     ]
     if unresolved:
         raise ValueError(f"Sex must be provided for ghost sample(s): {', '.join(unresolved)}")
-    return [member.sex for member in settings.family.members]
 
 
 def add_ghosts(settings: Settings) -> Settings:
@@ -93,7 +92,7 @@ def add_ghosts(settings: Settings) -> Settings:
         else:
             member.mother = ghost
             sex = "F"
-        settings.family.add_member(FamilyMember(id=ghost, sex=sex))
+        settings.family.members.append(FamilyMember(id=ghost, sex=sex))
     return settings
 
 
@@ -116,21 +115,20 @@ def sample_label(settings: Settings, sample: str) -> str:
     return sample
 
 
-def _generations(settings: Settings) -> list[int]:
+def _generations(settings: Settings) -> dict[str, int]:
     """Place samples one row below their deepest parent and partners on a shared row."""
-    index = {sample: position for position, sample in enumerate(settings.family.member_ids)}
-    depth = [0] * len(settings.family.members)
+    depth = {member.id: 0 for member in settings.family.members}
     couples = [
-        (index[father], index[mother])
+        (father, mother)
         for father, mother in _sibships(settings)
         if father and mother
     ]
     for _ in range(2 * len(depth) + 2):
         changed = False
-        for position, member in enumerate(settings.family.members):
+        for member in settings.family.members:
             for parent in (member.father, member.mother):
-                if parent in index and depth[position] <= depth[index[parent]]:
-                    depth[position] = depth[index[parent]] + 1
+                if parent in depth and depth[member.id] <= depth[parent]:
+                    depth[member.id] = depth[parent] + 1
                     changed = True
         for first, second in couples:
             shared = max(depth[first], depth[second])
@@ -161,7 +159,7 @@ def _separate(positions: dict[str, float], members: list[str], column: float) ->
         positions[right] = max(positions[right], positions[left] + column)
 
 
-def _layout(settings: Settings) -> tuple[dict[str, float], list[int]]:
+def _layout(settings: Settings) -> tuple[dict[str, float], dict[str, int]]:
     """Place every sample on a generation row with children centred under parents."""
     depth = _generations(settings)
     families = _sibships(settings)
@@ -176,11 +174,9 @@ def _layout(settings: Settings) -> tuple[dict[str, float], list[int]]:
     column = max(_COLUMN, 7.4 * widest + 18)
     rows: dict[int, list[str]] = {}
     positions: dict[str, float] = {}
-    for generation in sorted(set(depth)):
+    for generation in sorted(set(depth.values())):
         members = [
-            sample
-            for position, sample in enumerate(settings.family.member_ids)
-            if depth[position] == generation
+            sample for sample in settings.family.member_ids if depth[sample] == generation
         ]
         ordered: list[str] = []
         for sample in members:
@@ -199,26 +195,25 @@ def _layout(settings: Settings) -> tuple[dict[str, float], list[int]]:
         placed = [positions[sample] for sample in samples]
         return (min(placed) + max(placed)) / 2
 
-    index = {sample: position for position, sample in enumerate(settings.family.member_ids)}
     for _ in range(6):
         for (father, mother), children in families.items():
             parents = [parent for parent in (father, mother) if parent]
             shift = centre(parents) - centre(children)
             for child in children:
                 positions[child] += shift
-            _separate(positions, rows[depth[index[children[0]]]], column)
+            _separate(positions, rows[depth[children[0]]], column)
         for (father, mother), children in families.items():
             parents = [parent for parent in (father, mother) if parent]
             if any(
-                settings.family.member(parent).father in index
-                or settings.family.member(parent).mother in index
+                settings.family.member(parent).father in depth
+                or settings.family.member(parent).mother in depth
                 for parent in parents
             ):
                 continue
             shift = centre(children) - centre(parents)
             for parent in parents:
                 positions[parent] += shift
-            _separate(positions, rows[depth[index[parents[0]]]], column)
+            _separate(positions, rows[depth[parents[0]]], column)
     offset = _MARGIN - min(positions.values())
     return {sample: value + offset for sample, value in positions.items()}, depth
 
@@ -227,8 +222,7 @@ def pedigree_svg(settings: Settings) -> str:
     """Render the family as a conventional pedigree chart."""
     positions, depth = _layout(settings)
     families = _sibships(settings)
-    index = {sample: position for position, sample in enumerate(settings.family.member_ids)}
-    rows = {sample: _MARGIN + depth[index[sample]] * _GENERATION for sample in positions}
+    rows = {sample: _MARGIN + depth[sample] * _GENERATION for sample in positions}
     half = _SYMBOL / 2
 
     lines: list[str] = []
@@ -280,7 +274,7 @@ def pedigree_svg(settings: Settings) -> str:
         )
 
     width = max(positions.values()) + _MARGIN
-    height = _MARGIN + max(depth) * _GENERATION + _MARGIN + 20
+    height = _MARGIN + max(depth.values()) * _GENERATION + _MARGIN + 20
     return (
         f'<svg class="pedigree-svg" viewBox="0 0 {width:.0f} {height:.0f}" width="{width:.0f}" '
         'role="img" aria-label="Family tree">'

--- a/src/hopla/pipeline.py
+++ b/src/hopla/pipeline.py
@@ -37,8 +37,8 @@ def run_analysis(
 
     update("Loading VCF")
     sites, matrix = load_vcf(vcf_path, settings.real_samples)
-    settings.sexes = predict_sexes(settings, sites, matrix)
-    mask_male_x_heterozygotes(sites, matrix, settings.sample_ids, settings.sexes)
+    predict_sexes(settings, sites, matrix)
+    mask_male_x_heterozygotes(sites, matrix, settings)
     add_ghosts(settings)
     update("Applying filters")
     filtered1 = apply_filter1(sites, matrix, settings)
@@ -52,17 +52,19 @@ def run_analysis(
         if settings.run_merlin:
             update("Running Merlin")
             tables["haplotypes"] = run_merlin(
-                out_dir / f"{settings.fam_id}-merlin", sites, matrix, filtered2, settings
+                out_dir / f"{settings.family.id}-merlin", sites, matrix, filtered2, settings
             )
             if settings.concordance_table:
                 tables["haplotype_concordance"] = haplotype_concordance(tables["haplotypes"])
         if export_parquet_data:
             update("Writing portable Parquet exports")
-            export_parquet(out_dir / f"{settings.fam_id}-export", settings.fam_id, tables)
+            export_parquet(
+                out_dir / f"{settings.family.id}-export", settings.family.id, tables
+            )
         if export_bigwig:
             update("Writing IGV tracks")
-            export_igv_tracks(out_dir / f"{settings.fam_id}-export", tables, sizes)
+            export_igv_tracks(out_dir / f"{settings.family.id}-export", tables, sizes)
         update("Rendering report")
-        report = out_dir / f"{settings.fam_id}-output.html"
+        report = out_dir / f"{settings.family.id}-output.html"
         render_report(report, settings, tables, matrix.samples, cytobands)
     return report

--- a/src/hopla/report.py
+++ b/src/hopla/report.py
@@ -117,8 +117,8 @@ def _meta(
     sizes = chromosome_sizes(cytobands)
     parents = {
         sample: {
-            "father": settings.father_ids[settings.sample_ids.index(sample)],
-            "mother": settings.mother_ids[settings.sample_ids.index(sample)],
+            "father": settings.family.member(sample).father,
+            "mother": settings.family.member(sample).mother,
         }
         for sample in samples
     }
@@ -438,9 +438,9 @@ def render_report(
     ).decode("ascii")
     html = (
         "<!doctype html><html lang=\"en\"><head><meta charset=\"utf-8\">"
-        f"<title>{escape(settings.fam_id)}</title>"
+        f"<title>{escape(settings.family.id)}</title>"
         f"<style>{_STYLE}</style></head><body>"
-        f"<h1>{escape(settings.fam_id)}</h1>"
+        f"<h1>{escape(settings.family.id)}</h1>"
         + _body(settings, tables, samples, chromosomes)
         + f'<script id="hopla-data" type="application/gzip+json">{encoded}</script>'
         + f"<script>{_plotly_source()}</script>"

--- a/src/hopla/schema/hopla.schema.json
+++ b/src/hopla/schema/hopla.schema.json
@@ -4,12 +4,31 @@
   "title": "Hopla settings",
   "type": "object",
   "additionalProperties": false,
-  "required": ["sample_ids"],
+  "required": ["family"],
   "properties": {
-    "sample_ids": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}},
-    "father_ids": {"type": "array", "items": {"type": ["string", "null"]}},
-    "mother_ids": {"type": "array", "items": {"type": ["string", "null"]}},
-    "sexes": {"type": "array", "items": {"enum": ["M", "F", null]}},
+    "family": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["members"],
+      "properties": {
+        "id": {"type": "string", "minLength": 1, "default": "hopla"},
+        "members": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["id"],
+            "properties": {
+              "id": {"type": "string", "minLength": 1},
+              "father": {"type": ["string", "null"]},
+              "mother": {"type": ["string", "null"]},
+              "sex": {"enum": ["M", "F", null]}
+            }
+          }
+        }
+      }
+    },
     "run_merlin": {"type": "boolean", "default": true},
     "dp_hard_limit_ids": {"type": "array", "items": {"type": "string"}},
     "dp_hard_limit": {"type": "number", "minimum": 0, "default": 10},
@@ -34,7 +53,6 @@
     "keep_chromosomes_only": {"type": "boolean", "default": true},
     "keep_regions_only": {"type": "boolean", "default": false},
     "concordance_table": {"type": "boolean", "default": true},
-    "fam_id": {"type": "string", "minLength": 1, "default": "hopla"},
     "x_cutoff": {"type": "number", "default": 1.5},
     "y_cutoff": {"type": "number", "default": 0.6},
     "window_size": {"type": "number", "exclusiveMinimum": 0, "default": 1000000},

--- a/src/hopla/settings.py
+++ b/src/hopla/settings.py
@@ -191,6 +191,7 @@ def prepare_settings_mapping(raw: dict[str, Any]) -> tuple[dict[str, Any], list[
             prepared.pop(key)
     elif "sample_ids" in prepared:
         sample_ids = prepared.get("sample_ids")
+        members: Any
         if isinstance(sample_ids, list):
             size = len(sample_ids)
             aligned: dict[str, list[Any]] = {}

--- a/src/hopla/settings.py
+++ b/src/hopla/settings.py
@@ -11,7 +11,7 @@ from typing import Any, Literal
 
 import yaml
 from jsonschema import Draft7Validator
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, model_validator
 
 Sex = Literal["M", "F"] | None
 CLI_ONLY_KEYS = frozenset({"vcf_file", "out_dir", "cytoband_file"})
@@ -38,6 +38,49 @@ class Family(BaseModel):
 
     id: str = Field(default="hopla", min_length=1)
     members: list[FamilyMember] = Field(min_length=1)
+    _member_by_id: dict[str, FamilyMember] = PrivateAttr(default_factory=dict)
+
+    @model_validator(mode="after")
+    def validate_members(self) -> Family:
+        """Reject duplicate IDs, dangling parents, and unrelated member lists."""
+        member_ids = [member.id for member in self.members]
+        duplicates = sorted(
+            sample for sample in set(member_ids) if member_ids.count(sample) > 1
+        )
+        if duplicates:
+            raise ValueError(f"family member IDs must be unique: {', '.join(duplicates)}")
+        parents = [
+            parent
+            for member in self.members
+            for parent in (member.father, member.mother)
+            if parent is not None
+        ]
+        unknown = sorted(set(parents) - set(member_ids))
+        if unknown:
+            raise ValueError(f"sample references not found in family members: {', '.join(unknown)}")
+        if len(self.members) > 1 and not parents:
+            raise ValueError("multiple family members require a father and/or mother")
+        return self
+
+    def model_post_init(self, _context: Any) -> None:
+        """Build constant-time member lookup after validation."""
+        self._member_by_id = {member.id: member for member in self.members}
+
+    @property
+    def member_ids(self) -> tuple[str, ...]:
+        """Return member IDs in configured presentation order."""
+        return tuple(member.id for member in self.members)
+
+    def member(self, sample_id: str) -> FamilyMember:
+        """Return a family member by sample ID."""
+        return self._member_by_id[sample_id]
+
+    def add_member(self, member: FamilyMember) -> None:
+        """Append a generated pedigree member and update the ID lookup."""
+        if member.id in self._member_by_id:
+            raise ValueError(f"family member ID already exists: {member.id}")
+        self.members.append(member)
+        self._member_by_id[member.id] = member
 
 
 class Settings(BaseModel):
@@ -45,11 +88,7 @@ class Settings(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    family: Family | None = None
-    sample_ids: list[str] = Field(default_factory=list)
-    father_ids: list[str | None] = Field(default_factory=list)
-    mother_ids: list[str | None] = Field(default_factory=list)
-    sexes: list[Sex] = Field(default_factory=list)
+    family: Family
     run_merlin: bool = True
     dp_hard_limit_ids: list[str] = Field(default_factory=list)
     dp_hard_limit: float = Field(default=10, ge=0)
@@ -74,7 +113,6 @@ class Settings(BaseModel):
     keep_chromosomes_only: bool = True
     keep_regions_only: bool = False
     concordance_table: bool = True
-    fam_id: str = Field(default="hopla", min_length=1)
     x_cutoff: float = 1.5
     y_cutoff: float = 0.6
     window_size: int = Field(default=1_000_000, gt=0)
@@ -86,29 +124,7 @@ class Settings(BaseModel):
 
     @model_validator(mode="after")
     def validate_family(self) -> Settings:
-        """Expand and validate the structured pedigree and sample references."""
-        if self.family is not None:
-            self.sample_ids = [member.id for member in self.family.members]
-            self.father_ids = [member.father for member in self.family.members]
-            self.mother_ids = [member.mother for member in self.family.members]
-            self.sexes = [member.sex for member in self.family.members]
-            self.fam_id = self.family.id
-        if not self.sample_ids:
-            raise ValueError("family must contain at least one member")
-        duplicates = sorted(
-            sample for sample in set(self.sample_ids) if self.sample_ids.count(sample) > 1
-        )
-        if duplicates:
-            raise ValueError(f"family member IDs must be unique: {', '.join(duplicates)}")
-        size = len(self.sample_ids)
-        for name in ("father_ids", "mother_ids", "sexes"):
-            values = getattr(self, name)
-            if not values:
-                setattr(self, name, [None] * size)
-            elif len(values) != size:
-                raise ValueError(f"{name} must have the same length as sample_ids")
-        if size > 1 and not any(self.father_ids) and not any(self.mother_ids):
-            raise ValueError("multiple samples require father_ids and/or mother_ids")
+        """Validate top-level sample references and analysis regions."""
         referenced = (
             self.dp_hard_limit_ids
             + self.af_hard_limit_ids
@@ -120,32 +136,36 @@ class Settings(BaseModel):
             + self.affected_ids
             + self.nonaffected_ids
             + self.baf_ids
-            + [item for item in self.father_ids + self.mother_ids if item is not None]
         )
-        unknown = sorted(set(referenced) - set(self.sample_ids))
+        unknown = sorted(set(referenced) - set(self.family.member_ids))
         if unknown:
-            raise ValueError(f"sample references not found in sample_ids: {', '.join(unknown)}")
+            raise ValueError(f"sample references not found in family members: {', '.join(unknown)}")
         if len(self.keep_informative_ids) not in (0, 2):
             raise ValueError("keep_informative_ids must contain zero or two samples")
         for region in self.regions:
             if re.fullmatch(r"chr[^:]+:[0-9]+-[0-9]+", region) is None:
                 raise ValueError(f"invalid region: {region}")
         self.window_size_voting_x = self.window_size_voting_x or self.window_size_voting
-        self.fam_id = re.sub(r"[^\w]", ".", self.fam_id)
-        if self.family is not None:
-            self.family.id = self.fam_id
+        self.family.id = re.sub(r"[^\w]", ".", self.family.id)
         return self
 
     @property
     def real_samples(self) -> tuple[str, ...]:
         """Return samples backed by VCF columns rather than pedigree ghosts."""
         return tuple(
-            sample for sample in self.sample_ids if re.fullmatch(r"U[0-9]+", sample, re.I) is None
+            sample
+            for sample in self.family.member_ids
+            if re.fullmatch(r"U[0-9]+", sample, re.I) is None
         )
 
     def derive_filter_ids(self) -> Settings:
         """Fill filter sample lists using the original pedigree-derived defaults."""
-        parents = {item for item in self.father_ids + self.mother_ids if item in self.real_samples}
+        parents = {
+            parent
+            for member in self.family.members
+            for parent in (member.father, member.mother)
+            if parent in self.real_samples
+        }
         terminal = [sample for sample in self.real_samples if sample not in parents]
         if len(self.real_samples) == 1:
             parents = set(self.real_samples)

--- a/src/hopla/settings.py
+++ b/src/hopla/settings.py
@@ -11,7 +11,7 @@ from typing import Any, Literal
 
 import yaml
 from jsonschema import Draft7Validator
-from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 Sex = Literal["M", "F"] | None
 CLI_ONLY_KEYS = frozenset({"vcf_file", "out_dir", "cytoband_file"})
@@ -21,7 +21,7 @@ LEGACY_FAMILY_KEYS = frozenset(
 
 
 class FamilyMember(BaseModel):
-    """Describe one family member without positional cross-references."""
+    """One pedigree member."""
 
     model_config = ConfigDict(extra="forbid")
 
@@ -32,13 +32,12 @@ class FamilyMember(BaseModel):
 
 
 class Family(BaseModel):
-    """Group a named family and its pedigree members."""
+    """Named family and its members."""
 
     model_config = ConfigDict(extra="forbid")
 
     id: str = Field(default="hopla", min_length=1)
     members: list[FamilyMember] = Field(min_length=1)
-    _member_by_id: dict[str, FamilyMember] = PrivateAttr(default_factory=dict)
 
     @model_validator(mode="after")
     def validate_members(self) -> Family:
@@ -62,25 +61,21 @@ class Family(BaseModel):
             raise ValueError("multiple family members require a father and/or mother")
         return self
 
-    def model_post_init(self, _context: object) -> None:
-        """Build constant-time member lookup after validation."""
-        self._member_by_id = {member.id: member for member in self.members}
-
     @property
     def member_ids(self) -> tuple[str, ...]:
-        """Return member IDs in configured presentation order."""
+        """Return member IDs in declaration order."""
         return tuple(member.id for member in self.members)
 
     def member(self, sample_id: str) -> FamilyMember:
-        """Return a family member by sample ID."""
-        return self._member_by_id[sample_id]
+        """Return the member with this sample ID."""
+        for item in self.members:
+            if item.id == sample_id:
+                return item
+        raise KeyError(sample_id)
 
     def add_member(self, member: FamilyMember) -> None:
-        """Append a generated pedigree member and update the ID lookup."""
-        if member.id in self._member_by_id:
-            raise ValueError(f"family member ID already exists: {member.id}")
+        """Append a generated pedigree member."""
         self.members.append(member)
-        self._member_by_id[member.id] = member
 
 
 class Settings(BaseModel):
@@ -203,15 +198,13 @@ def prepare_settings_mapping(raw: dict[str, Any]) -> tuple[dict[str, Any], list[
     for key in CLI_ONLY_KEYS:
         prepared.pop(key, None)
     ignored: list[str] = []
-    supplied_family = "family" in prepared
-    if supplied_family:
+    if "family" in prepared:
         conflicting = sorted(LEGACY_FAMILY_KEYS.intersection(prepared))
         ignored.extend(conflicting)
         for key in conflicting:
             prepared.pop(key)
     elif "sample_ids" in prepared:
-        sample_ids = prepared.get("sample_ids")
-        members: Any
+        sample_ids = prepared["sample_ids"]
         if isinstance(sample_ids, list):
             size = len(sample_ids)
             aligned: dict[str, list[Any]] = {}
@@ -225,18 +218,19 @@ def prepare_settings_mapping(raw: dict[str, Any]) -> tuple[dict[str, Any], list[
                     raise ValueError(f"{key} must have the same length as sample_ids")
                 else:
                     aligned[key] = values
-            members = [
-                {
-                    "id": sample_id,
-                    "father": aligned["father_ids"][index],
-                    "mother": aligned["mother_ids"][index],
-                    "sex": aligned["sexes"][index],
-                }
-                for index, sample_id in enumerate(sample_ids)
-            ]
+            family: dict[str, Any] = {
+                "members": [
+                    {
+                        "id": sample_id,
+                        "father": aligned["father_ids"][index],
+                        "mother": aligned["mother_ids"][index],
+                        "sex": aligned["sexes"][index],
+                    }
+                    for index, sample_id in enumerate(sample_ids)
+                ]
+            }
         else:
-            members = sample_ids
-        family: dict[str, Any] = {"members": members}
+            family = {"members": sample_ids}
         if "fam_id" in prepared:
             family["id"] = prepared["fam_id"]
         prepared["family"] = family

--- a/src/hopla/settings.py
+++ b/src/hopla/settings.py
@@ -62,7 +62,7 @@ class Family(BaseModel):
             raise ValueError("multiple family members require a father and/or mother")
         return self
 
-    def model_post_init(self, _context: Any) -> None:
+    def model_post_init(self, _context: object) -> None:
         """Build constant-time member lookup after validation."""
         self._member_by_id = {member.id: member for member in self.members}
 

--- a/src/hopla/settings.py
+++ b/src/hopla/settings.py
@@ -73,11 +73,6 @@ class Family(BaseModel):
                 return item
         raise KeyError(sample_id)
 
-    def add_member(self, member: FamilyMember) -> None:
-        """Append a generated pedigree member."""
-        self.members.append(member)
-
-
 class Settings(BaseModel):
     """Model all supported analysis settings."""
 
@@ -192,6 +187,43 @@ def schema_properties() -> dict[str, Any]:
     return properties
 
 
+def _aligned_column(name: str, values: object, size: int) -> list[Any]:
+    if values in (None, []):
+        return [None] * size
+    if not isinstance(values, list) or len(values) != size:
+        raise ValueError(f"{name} must have the same length as sample_ids")
+    return values
+
+
+def family_from_parallel_arrays(
+    sample_ids: list[Any],
+    *,
+    father_ids: object = None,
+    mother_ids: object = None,
+    sexes: object = None,
+    fam_id: object = None,
+) -> dict[str, Any]:
+    """Zip historical parallel pedigree arrays into a family object."""
+    size = len(sample_ids)
+    fathers = _aligned_column("father_ids", father_ids, size)
+    mothers = _aligned_column("mother_ids", mother_ids, size)
+    sexes_column = _aligned_column("sexes", sexes, size)
+    family: dict[str, Any] = {
+        "members": [
+            {
+                "id": sample_id,
+                "father": fathers[index],
+                "mother": mothers[index],
+                "sex": sexes_column[index],
+            }
+            for index, sample_id in enumerate(sample_ids)
+        ]
+    }
+    if fam_id is not None:
+        family["id"] = fam_id
+    return family
+
+
 def prepare_settings_mapping(raw: dict[str, Any]) -> tuple[dict[str, Any], list[str]]:
     """Remap historical names, coerce `info`, and drop unsupported keys."""
     prepared = dict(raw)
@@ -203,37 +235,17 @@ def prepare_settings_mapping(raw: dict[str, Any]) -> tuple[dict[str, Any], list[
         ignored.extend(conflicting)
         for key in conflicting:
             prepared.pop(key)
-    elif "sample_ids" in prepared:
-        sample_ids = prepared["sample_ids"]
-        if isinstance(sample_ids, list):
-            size = len(sample_ids)
-            aligned: dict[str, list[Any]] = {}
-            for key in ("father_ids", "mother_ids", "sexes"):
-                values = prepared.get(key)
-                if key == "sexes" and values is None:
-                    values = prepared.get("genders")
-                if values in (None, []):
-                    aligned[key] = [None] * size
-                elif not isinstance(values, list) or len(values) != size:
-                    raise ValueError(f"{key} must have the same length as sample_ids")
-                else:
-                    aligned[key] = values
-            family: dict[str, Any] = {
-                "members": [
-                    {
-                        "id": sample_id,
-                        "father": aligned["father_ids"][index],
-                        "mother": aligned["mother_ids"][index],
-                        "sex": aligned["sexes"][index],
-                    }
-                    for index, sample_id in enumerate(sample_ids)
-                ]
-            }
-        else:
-            family = {"members": sample_ids}
-        if "fam_id" in prepared:
-            family["id"] = prepared["fam_id"]
-        prepared["family"] = family
+    elif isinstance(prepared.get("sample_ids"), list):
+        sexes = prepared.get("sexes")
+        if sexes is None:
+            sexes = prepared.get("genders")
+        prepared["family"] = family_from_parallel_arrays(
+            prepared["sample_ids"],
+            father_ids=prepared.get("father_ids"),
+            mother_ids=prepared.get("mother_ids"),
+            sexes=sexes,
+            fam_id=prepared.get("fam_id"),
+        )
         for key in LEGACY_FAMILY_KEYS:
             prepared.pop(key, None)
     if isinstance(prepared.get("info"), list):

--- a/src/hopla/settings.py
+++ b/src/hopla/settings.py
@@ -15,6 +15,29 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 Sex = Literal["M", "F"] | None
 CLI_ONLY_KEYS = frozenset({"vcf_file", "out_dir", "cytoband_file"})
+LEGACY_FAMILY_KEYS = frozenset(
+    {"sample_ids", "father_ids", "mother_ids", "sexes", "genders", "fam_id"}
+)
+
+
+class FamilyMember(BaseModel):
+    """Describe one family member without positional cross-references."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str = Field(min_length=1)
+    father: str | None = None
+    mother: str | None = None
+    sex: Sex = None
+
+
+class Family(BaseModel):
+    """Group a named family and its pedigree members."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str = Field(default="hopla", min_length=1)
+    members: list[FamilyMember] = Field(min_length=1)
 
 
 class Settings(BaseModel):
@@ -22,7 +45,8 @@ class Settings(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    sample_ids: list[str] = Field(min_length=1)
+    family: Family | None = None
+    sample_ids: list[str] = Field(default_factory=list)
     father_ids: list[str | None] = Field(default_factory=list)
     mother_ids: list[str | None] = Field(default_factory=list)
     sexes: list[Sex] = Field(default_factory=list)
@@ -62,7 +86,20 @@ class Settings(BaseModel):
 
     @model_validator(mode="after")
     def validate_family(self) -> Settings:
-        """Validate parallel pedigree arrays, references, and regions."""
+        """Expand and validate the structured pedigree and sample references."""
+        if self.family is not None:
+            self.sample_ids = [member.id for member in self.family.members]
+            self.father_ids = [member.father for member in self.family.members]
+            self.mother_ids = [member.mother for member in self.family.members]
+            self.sexes = [member.sex for member in self.family.members]
+            self.fam_id = self.family.id
+        if not self.sample_ids:
+            raise ValueError("family must contain at least one member")
+        duplicates = sorted(
+            sample for sample in set(self.sample_ids) if self.sample_ids.count(sample) > 1
+        )
+        if duplicates:
+            raise ValueError(f"family member IDs must be unique: {', '.join(duplicates)}")
         size = len(self.sample_ids)
         for name in ("father_ids", "mother_ids", "sexes"):
             values = getattr(self, name)
@@ -95,6 +132,8 @@ class Settings(BaseModel):
                 raise ValueError(f"invalid region: {region}")
         self.window_size_voting_x = self.window_size_voting_x or self.window_size_voting
         self.fam_id = re.sub(r"[^\w]", ".", self.fam_id)
+        if self.family is not None:
+            self.family.id = self.fam_id
         return self
 
     @property
@@ -144,12 +183,44 @@ def prepare_settings_mapping(raw: dict[str, Any]) -> tuple[dict[str, Any], list[
     for key in CLI_ONLY_KEYS:
         prepared.pop(key, None)
     ignored: list[str] = []
-    if "genders" in prepared:
-        if "sexes" not in prepared:
-            prepared["sexes"] = prepared.pop("genders")
+    supplied_family = "family" in prepared
+    if supplied_family:
+        conflicting = sorted(LEGACY_FAMILY_KEYS.intersection(prepared))
+        ignored.extend(conflicting)
+        for key in conflicting:
+            prepared.pop(key)
+    elif "sample_ids" in prepared:
+        sample_ids = prepared.get("sample_ids")
+        if isinstance(sample_ids, list):
+            size = len(sample_ids)
+            aligned: dict[str, list[Any]] = {}
+            for key in ("father_ids", "mother_ids", "sexes"):
+                values = prepared.get(key)
+                if key == "sexes" and values is None:
+                    values = prepared.get("genders")
+                if values in (None, []):
+                    aligned[key] = [None] * size
+                elif not isinstance(values, list) or len(values) != size:
+                    raise ValueError(f"{key} must have the same length as sample_ids")
+                else:
+                    aligned[key] = values
+            members = [
+                {
+                    "id": sample_id,
+                    "father": aligned["father_ids"][index],
+                    "mother": aligned["mother_ids"][index],
+                    "sex": aligned["sexes"][index],
+                }
+                for index, sample_id in enumerate(sample_ids)
+            ]
         else:
-            prepared.pop("genders")
-            ignored.append("genders")
+            members = sample_ids
+        family: dict[str, Any] = {"members": members}
+        if "fam_id" in prepared:
+            family["id"] = prepared["fam_id"]
+        prepared["family"] = family
+        for key in LEGACY_FAMILY_KEYS:
+            prepared.pop(key, None)
     if isinstance(prepared.get("info"), list):
         prepared["info"] = "\n".join(str(line) for line in prepared["info"])
     allowed = set(schema_properties())

--- a/src/hopla/ui/form.py
+++ b/src/hopla/ui/form.py
@@ -96,15 +96,15 @@ def default_form() -> dict[str, Any]:
 
 def _pedigree_mapping(settings: dict[str, Any]) -> dict[str, Any]:
     family_members = settings["family"]["members"]
-    sample_ids = [str(member["id"]) for member in family_members]
     members = {
-        sample_id: {
+        str(member["id"]): {
             "father": member.get("father"),
             "mother": member.get("mother"),
             "index": index,
         }
-        for index, (sample_id, member) in enumerate(zip(sample_ids, family_members, strict=True))
+        for index, member in enumerate(family_members)
     }
+    sample_ids = list(members)
 
     def depth(sample_id: str, visiting: set[str]) -> int:
         if sample_id in visiting or sample_id not in members:

--- a/src/hopla/ui/form.py
+++ b/src/hopla/ui/form.py
@@ -19,10 +19,7 @@ PLACEHOLDERS = {
     "maternal_grandmother": "U6",
 }
 CONTROLLED_KEYS = {
-    "sample_ids",
-    "father_ids",
-    "mother_ids",
-    "sexes",
+    "family",
     "dp_hard_limit_ids",
     "af_hard_limit_ids",
     "af_hard_limit",
@@ -38,7 +35,6 @@ CONTROLLED_KEYS = {
     "window_size_voting",
     "keep_chromosomes_only",
     "keep_regions_only",
-    "fam_id",
     "regions_flanking_size",
     "limit_baf_to_p",
     "limit_pm_to_p",
@@ -99,14 +95,15 @@ def default_form() -> dict[str, Any]:
 
 
 def _pedigree_mapping(settings: dict[str, Any]) -> dict[str, Any]:
-    sample_ids = [str(value) for value in settings["sample_ids"]]
-    fathers = list(settings.get("father_ids") or [None] * len(sample_ids))
-    mothers = list(settings.get("mother_ids") or [None] * len(sample_ids))
-    fathers.extend([None] * (len(sample_ids) - len(fathers)))
-    mothers.extend([None] * (len(sample_ids) - len(mothers)))
+    family_members = settings["family"]["members"]
+    sample_ids = [str(member["id"]) for member in family_members]
     members = {
-        sample_id: {"father": fathers[index], "mother": mothers[index], "index": index}
-        for index, sample_id in enumerate(sample_ids)
+        sample_id: {
+            "father": member.get("father"),
+            "mother": member.get("mother"),
+            "index": index,
+        }
+        for index, (sample_id, member) in enumerate(zip(sample_ids, family_members, strict=True))
     }
 
     def depth(sample_id: str, visiting: set[str]) -> int:
@@ -160,9 +157,8 @@ def settings_to_form(settings: dict[str, Any]) -> dict[str, Any]:
     validate_settings(settings)
     state = default_form()
     mapping = _pedigree_mapping(settings)
-    sample_ids = list(settings["sample_ids"])
-    sexes = list(settings.get("sexes") or [None] * len(sample_ids))
-    sex_by_id = dict(zip(sample_ids, sexes, strict=False))
+    family_members = settings["family"]["members"]
+    sex_by_id = {member["id"]: member.get("sex") for member in family_members}
     fixed: dict[str, Any] = {}
     for role, placeholder in PLACEHOLDERS.items():
         sample_id = mapping.get(role) or placeholder
@@ -179,7 +175,7 @@ def settings_to_form(settings: dict[str, Any]) -> dict[str, Any]:
         _member("embryo", sample_id, sex_by_id.get(sample_id), settings)
         for sample_id in mapping.get("embryos", [])
     ]
-    state["fam_id"] = settings.get("fam_id", state["fam_id"])
+    state["fam_id"] = settings["family"].get("id", "hopla")
     for key in (
         "af_hard_limit",
         "regions",
@@ -242,8 +238,7 @@ def form_to_settings(state: dict[str, Any]) -> dict[str, Any]:
             else None,
         ),
     }
-    father_ids: list[str | None] = []
-    mother_ids: list[str | None] = []
+    family_members: list[dict[str, Any]] = []
     for member in selected:
         role = member["role"]
         if role in parent_by_role:
@@ -252,8 +247,14 @@ def form_to_settings(state: dict[str, Any]) -> dict[str, Any]:
             member_father, member_mother = father, mother
         else:
             member_father, member_mother = None, None
-        father_ids.append(member_father)
-        mother_ids.append(member_mother)
+        family_members.append(
+            {
+                "id": member["sample_id"],
+                "father": member_father,
+                "mother": member_mother,
+                "sex": None if member.get("sex") == "NA" else member.get("sex"),
+            }
+        )
 
     def ids(flag: str) -> list[str]:
         return [str(member["sample_id"]) for member in selected if member.get(flag, False)]
@@ -273,13 +274,7 @@ def form_to_settings(state: dict[str, Any]) -> dict[str, Any]:
     result: dict[str, Any] = dict(state.get("extras", {}))
     result.update(
         {
-            "sample_ids": [member["sample_id"] for member in selected],
-            "father_ids": father_ids,
-            "mother_ids": mother_ids,
-            "sexes": [
-                None if member.get("sex") == "NA" else member.get("sex")
-                for member in selected
-            ],
+            "family": {"id": str(state["fam_id"]), "members": family_members},
             "dp_hard_limit_ids": ids("hard_dp"),
             "af_hard_limit_ids": ids("hard_af"),
             "af_hard_limit": float(state["af_hard_limit"]),
@@ -293,7 +288,6 @@ def form_to_settings(state: dict[str, Any]) -> dict[str, Any]:
             "window_size_voting": float(state["window_size_voting"]),
             "keep_chromosomes_only": bool(state["keep_chromosomes_only"]),
             "keep_regions_only": bool(state["keep_regions_only"]),
-            "fam_id": str(state["fam_id"]),
             "regions_flanking_size": int(state["regions_flanking_size"]),
             "limit_baf_to_p": bool(state["limit_baf_to_p"]),
             "limit_pm_to_p": bool(state["limit_pm_to_p"]),

--- a/src/hopla/vcf.py
+++ b/src/hopla/vcf.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
 
@@ -10,6 +9,7 @@ import numpy as np
 from cyvcf2 import VCF  # type: ignore[import-untyped]
 
 from hopla.models import CHROMOSOME_CODES, GenotypeMatrix, SiteTable
+from hopla.settings import Settings
 
 # cyvcf2 pads ragged genotype rows so that mixed-ploidy sites stay rectangular.
 ABSENT_ALLELE = -2
@@ -111,12 +111,11 @@ def load_vcf(path: Path, samples: tuple[str, ...]) -> tuple[SiteTable, GenotypeM
 def mask_male_x_heterozygotes(
     sites: SiteTable,
     matrix: GenotypeMatrix,
-    sample_ids: Sequence[str],
-    sexes: Sequence[str | None],
+    settings: Settings,
 ) -> None:
     """Mark diploid heterozygous chromosome-X calls missing in male samples."""
     x_mask = sites.chrom == CHROMOSOME_CODES["chrX"]
     for sample in matrix.samples:
-        if sexes[sample_ids.index(sample)] == "M":
+        if settings.family.member(sample).sex == "M":
             sample_index = matrix.sample_index[sample]
             matrix.gt[sample_index, x_mask & (matrix.gt[sample_index] == 1)] = -1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,10 +41,11 @@ def settings_file(tmp_path: Path) -> Path:
     path = tmp_path / "settings.yaml"
     path.write_text(
         """
-sample_ids: [FATHER, MOTHER, CHILD]
-father_ids: [null, null, FATHER]
-mother_ids: [null, null, MOTHER]
-sexes: [M, F, F]
+family:
+  members:
+    - {id: FATHER, sex: M}
+    - {id: MOTHER, sex: F}
+    - {id: CHILD, father: FATHER, mother: MOTHER, sex: F}
 run_merlin: false
 keep_informative_ids: [FATHER, MOTHER]
 baf_ids: [CHILD]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -44,7 +44,13 @@ def test_convert_concordance_and_transform(tmp_path: Path) -> None:
     converted = runner.invoke(app, ["convert", str(legacy)])
     assert converted.exit_code == 0
     assert legacy.with_suffix(".yaml").read_text(encoding="utf-8") == (
-        "sample_ids:\n- A\nsexes:\n- null\nrun_merlin: false\n"
+        "run_merlin: false\n"
+        "family:\n"
+        "  members:\n"
+        "  - id: A\n"
+        "    father: null\n"
+        "    mother: null\n"
+        "    sex: null\n"
     )
     first, second = tmp_path / "one-flow.txt", tmp_path / "two-flow.txt"
     _flow(first)

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -166,7 +166,7 @@ def test_af_rounding_and_y_model_conflict_resolution() -> None:
 
 
 def test_unsupported_settings_are_ignored(caplog: pytest.LogCaptureFixture) -> None:
-    """Remap historical `genders` and drop unused keys after a warning."""
+    """Remap the historical pedigree arrays and drop unused keys."""
     with caplog.at_level(logging.WARNING):
         settings = validate_settings(
             {
@@ -177,5 +177,24 @@ def test_unsupported_settings_are_ignored(caplog: pytest.LogCaptureFixture) -> N
             }
         )
     assert settings.sexes == ["M"]
+    assert settings.family is not None
+    assert settings.family.members[0].id == "A"
     assert "bogus" in caplog.text
     assert "self_contained" in caplog.text
+
+
+def test_structured_family_wins_over_parallel_arrays(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Prefer the canonical family when both config representations exist."""
+    with caplog.at_level(logging.WARNING):
+        settings = validate_settings(
+            {
+                "family": {"members": [{"id": "CANONICAL"}]},
+                "sample_ids": ["LEGACY"],
+                "sexes": ["M"],
+            }
+        )
+    assert settings.sample_ids == ["CANONICAL"]
+    assert "sample_ids" in caplog.text
+    assert "sexes" in caplog.text

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -12,7 +12,7 @@ from hopla.analysis import _duo_errors, _trio_errors
 from hopla.filters import apply_filter1, apply_filter2
 from hopla.merlin import _marker_indices, _parse_blocks, correct_short_segments, weighted_vote
 from hopla.models import GenotypeMatrix, SiteTable
-from hopla.pedigree import predict_sexes
+from hopla.pedigree import add_ghosts, predict_sexes
 from hopla.settings import Settings, load_settings, validate_settings
 from hopla.vcf import load_vcf, mask_male_x_heterozygotes
 
@@ -23,7 +23,7 @@ def test_vcf_and_filters(family_vcf: Path, settings_file: Path) -> None:
     sites, matrix = load_vcf(family_vcf, settings.real_samples)
     assert sites.size == 46
     assert matrix.gt.shape == (3, 46)
-    mask_male_x_heterozygotes(sites, matrix, settings.sample_ids, settings.sexes)
+    mask_male_x_heterozygotes(sites, matrix, settings)
     assert matrix.gt[matrix.sample_index["FATHER"], -1] == -1
     filtered1 = apply_filter1(sites, matrix, settings)
     filtered2 = apply_filter2(sites, matrix, filtered1, settings)
@@ -161,8 +161,9 @@ def test_af_rounding_and_y_model_conflict_resolution() -> None:
         sample_index={"sample": 0},
     )
     assert np.allclose(matrix.allele_fraction()[0], [0.333, 0.667, 0.667])
-    settings = Settings(sample_ids=["sample"], sexes=[None], run_merlin=False)
+    settings = Settings(family={"members": [{"id": "sample"}]}, run_merlin=False)
     assert predict_sexes(settings, sites, matrix) == ["M"]
+    assert settings.family.member("sample").sex == "M"
 
 
 def test_unsupported_settings_are_ignored(caplog: pytest.LogCaptureFixture) -> None:
@@ -176,8 +177,7 @@ def test_unsupported_settings_are_ignored(caplog: pytest.LogCaptureFixture) -> N
                 "bogus": 1,
             }
         )
-    assert settings.sexes == ["M"]
-    assert settings.family is not None
+    assert settings.family.member("A").sex == "M"
     assert settings.family.members[0].id == "A"
     assert "bogus" in caplog.text
     assert "self_contained" in caplog.text
@@ -195,6 +195,25 @@ def test_structured_family_wins_over_parallel_arrays(
                 "sexes": ["M"],
             }
         )
-    assert settings.sample_ids == ["CANONICAL"]
+    assert settings.family.member_ids == ("CANONICAL",)
     assert "sample_ids" in caplog.text
     assert "sexes" in caplog.text
+
+
+def test_generated_ghost_is_added_to_structured_family() -> None:
+    """Add a missing parent without creating parallel pedigree state."""
+    settings = validate_settings(
+        {
+            "family": {
+                "members": [
+                    {"id": "FATHER", "sex": "M"},
+                    {"id": "CHILD", "father": "FATHER", "sex": "F"},
+                ]
+            },
+            "run_merlin": False,
+        }
+    )
+    add_ghosts(settings)
+    assert settings.family.member("CHILD").mother == "U1"
+    assert settings.family.member("U1").sex == "F"
+    assert settings.family.member_ids == ("FATHER", "CHILD", "U1")

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -162,7 +162,7 @@ def test_af_rounding_and_y_model_conflict_resolution() -> None:
     )
     assert np.allclose(matrix.allele_fraction()[0], [0.333, 0.667, 0.667])
     settings = Settings(family={"members": [{"id": "sample"}]}, run_merlin=False)
-    assert predict_sexes(settings, sites, matrix) == ["M"]
+    predict_sexes(settings, sites, matrix)
     assert settings.family.member("sample").sex == "M"
 
 

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -24,10 +24,13 @@ CYTOBANDS = (
 def _trio() -> Settings:
     """Build a father, mother, and affected child."""
     return Settings(
-        sample_ids=["father", "mother", "child"],
-        father_ids=[None, None, "father"],
-        mother_ids=[None, None, "mother"],
-        sexes=["M", "F", "M"],
+        family={
+            "members": [
+                {"id": "father", "sex": "M"},
+                {"id": "mother", "sex": "F"},
+                {"id": "child", "father": "father", "mother": "mother", "sex": "M"},
+            ]
+        },
         affected_ids=["child"],
         nonaffected_ids=["father"],
         carrier_ids=["mother"],
@@ -70,14 +73,24 @@ def test_pedigree_styles_never_reach_the_plotly_figures() -> None:
 def test_pedigree_pulls_a_founder_partner_down_to_their_spouse_row() -> None:
     """Keep couples on one row so their relationship line never spans generations."""
     settings = Settings(
-        sample_ids=["grandmother", "grandfather", "mother", "father", "child"],
-        father_ids=[None, None, "grandfather", None, "father"],
-        mother_ids=[None, None, "grandmother", None, "mother"],
-        sexes=["F", "M", "F", "M", "F"],
+        family={
+            "members": [
+                {"id": "grandmother", "sex": "F"},
+                {"id": "grandfather", "sex": "M"},
+                {
+                    "id": "mother",
+                    "father": "grandfather",
+                    "mother": "grandmother",
+                    "sex": "F",
+                },
+                {"id": "father", "sex": "M"},
+                {"id": "child", "father": "father", "mother": "mother", "sex": "F"},
+            ]
+        },
         run_merlin=False,
     )
     positions, depth = _layout(settings)
-    generation = dict(zip(settings.sample_ids, depth, strict=True))
+    generation = dict(zip(settings.family.member_ids, depth, strict=True))
     assert generation["grandmother"] == generation["grandfather"] == 0
     # The father has no parents but marries into the second generation.
     assert generation["mother"] == generation["father"] == 1

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -45,7 +45,7 @@ def test_pedigree_places_children_below_and_between_their_parents() -> None:
     """Draw generations as rows with the sibship centred under the parent couple."""
     settings = _trio()
     positions, depth = _layout(settings)
-    assert depth == [0, 0, 1]
+    assert depth == {"father": 0, "mother": 0, "child": 1}
     assert positions["child"] == (positions["father"] + positions["mother"]) / 2
     assert positions["father"] != positions["mother"]
 
@@ -90,11 +90,10 @@ def test_pedigree_pulls_a_founder_partner_down_to_their_spouse_row() -> None:
         run_merlin=False,
     )
     positions, depth = _layout(settings)
-    generation = dict(zip(settings.family.member_ids, depth, strict=True))
-    assert generation["grandmother"] == generation["grandfather"] == 0
+    assert depth["grandmother"] == depth["grandfather"] == 0
     # The father has no parents but marries into the second generation.
-    assert generation["mother"] == generation["father"] == 1
-    assert generation["child"] == 2
+    assert depth["mother"] == depth["father"] == 1
+    assert depth["child"] == 2
     assert positions["child"] == (positions["mother"] + positions["father"]) / 2
 
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -55,11 +55,11 @@ def test_structured_family_is_independent_of_member_order() -> None:
             "run_merlin": False,
         }
     )
-    assert settings.sample_ids == ["CHILD", "MOTHER", "FATHER"]
-    assert settings.father_ids == ["FATHER", None, None]
-    assert settings.mother_ids == ["MOTHER", None, None]
-    assert settings.sexes == [None, "F", "M"]
-    assert settings.fam_id == "family.one"
+    assert settings.family.member_ids == ("CHILD", "MOTHER", "FATHER")
+    assert settings.family.member("CHILD").father == "FATHER"
+    assert settings.family.member("CHILD").mother == "MOTHER"
+    assert [member.sex for member in settings.family.members] == [None, "F", "M"]
+    assert settings.family.id == "family.one"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -6,7 +6,9 @@ import json
 import tomllib
 from pathlib import Path
 
-from hopla.settings import schema_path
+import pytest
+
+from hopla.settings import schema_path, validate_settings
 
 PACKAGE_ROOT = Path(__file__).resolve().parents[1]
 LOCAL_SCHEMA = PACKAGE_ROOT / "src" / "hopla" / "schema" / "hopla.schema.json"
@@ -36,3 +38,41 @@ def test_pyproject_ships_local_schema() -> None:
     assert (PACKAGE_ROOT / "src/hopla/ui/static/app.js").is_file()
     serialized = (PACKAGE_ROOT / "pyproject.toml").read_text(encoding="utf-8")
     assert "hopla/schema/hopla.schema.json" in serialized
+
+
+def test_structured_family_is_independent_of_member_order() -> None:
+    """Resolve parent links by member ID rather than parallel-array position."""
+    settings = validate_settings(
+        {
+            "family": {
+                "id": "family one",
+                "members": [
+                    {"id": "CHILD", "father": "FATHER", "mother": "MOTHER"},
+                    {"id": "MOTHER", "sex": "F"},
+                    {"id": "FATHER", "sex": "M"},
+                ],
+            },
+            "run_merlin": False,
+        }
+    )
+    assert settings.sample_ids == ["CHILD", "MOTHER", "FATHER"]
+    assert settings.father_ids == ["FATHER", None, None]
+    assert settings.mother_ids == ["MOTHER", None, None]
+    assert settings.sexes == [None, "F", "M"]
+    assert settings.fam_id == "family.one"
+
+
+@pytest.mark.parametrize(
+    ("family", "message"),
+    [
+        ({"members": [{"id": "A"}, {"id": "A"}]}, "must be unique"),
+        ({"members": [{"id": "A", "role": "child"}]}, "Additional properties"),
+        ({"members": [{"id": "A", "father": "UNKNOWN"}]}, "not found"),
+    ],
+)
+def test_structured_family_rejects_invalid_members(
+    family: dict[str, object], message: str
+) -> None:
+    """Reject duplicate IDs, unknown properties, and dangling parents."""
+    with pytest.raises(ValueError, match=message):
+        validate_settings({"family": family})

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -198,13 +198,13 @@ def test_stream_vcf_run_and_download_report(
         progress: ProgressCallback | None = None,
     ) -> Path:
         del cytoband_path
-        assert settings.sample_ids == ["FATHER"]
+        assert settings.family.member_ids == ("FATHER",)
         assert vcf_path.read_bytes() == b"VCF data"
         assert export_parquet_data is False
         assert export_bigwig is False
         assert progress is not None
         progress("Computing analyses")
-        report = out_dir / f"{settings.fam_id}-output.html"
+        report = out_dir / f"{settings.family.id}-output.html"
         report.write_text("<html>report</html>", encoding="utf-8")
         return report
 

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -34,7 +34,9 @@ def test_editor_and_validated_download() -> None:
         assert preview.status_code == 200
         settings = yaml.safe_load(preview.json()["yaml"])
         validate_settings(settings)
-        assert settings["sample_ids"] == ["FATHER"]
+        assert settings["family"]["members"] == [
+            {"id": "FATHER", "father": None, "mother": None, "sex": "M"}
+        ]
         assert "vcf_file" not in settings
         assert "cytoband_file" not in settings
 
@@ -77,10 +79,10 @@ def test_add_sibling_state_and_validation_error() -> None:
     }
     state["siblings"].append(sibling)
     settings = yaml.safe_load(render_yaml(state))
-    assert settings["father_ids"] == [None, "FATHER"]
+    assert settings["family"]["members"][1]["father"] == "FATHER"
     assert settings["affected_ids"] == ["CHILD"]
     assert settings["baf_ids"] == ["CHILD"]
-    assert settings["sexes"] == ["M", "F"]
+    assert [member["sex"] for member in settings["family"]["members"]] == ["M", "F"]
     assert "self_contained" not in settings
     assert "color_palette" not in settings
     assert "cairo" not in settings
@@ -142,7 +144,7 @@ def test_import_legacy_and_ignore_unknown_setting() -> None:
         assert ignored.status_code == 200
         assert ignored.json()["warnings"] == ["unknown"]
         generated = yaml.safe_load(render_yaml(ignored.json()["form"]))
-        assert generated["sample_ids"] == ["A"]
+        assert generated["family"]["members"][0]["id"] == "A"
         assert "unknown" not in generated
 
         rejected = client.post(
@@ -156,7 +158,7 @@ def test_settings_to_form_preserves_unedited_schema_fields() -> None:
     """Carry settings without form controls through an import/export cycle."""
     state = settings_to_form(
         {
-            "sample_ids": ["A"],
+            "family": {"members": [{"id": "A"}]},
             "run_merlin": False,
             "dot_factor": 3,
         }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- replace order-aligned pedigree configuration arrays with `family.id` and `family.members`
- use structured members as the engine’s sole runtime pedigree model, with constant-time lookup by member ID
- remap legacy parallel-array YAML and key-value settings before schema validation
- update the settings editor, examples, docs, and tests for the structured representation
- keep package and CLI version at 3.0.0

## Verification
- `pixi install --locked`
- `pixi run -e dev lint-py`
- `pixi run -e dev test-py` (34 passed)
- `pixi run -e dev python -m pip wheel --no-deps . -w dist`
- browser-tested family editing, child parent links, canonical YAML preview, example import, duplicate-ID validation, tabs, and download

Docker verification was unavailable because Docker is not installed in the environment.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b71bbb26-0643-4d1c-a86a-ba6003a77885?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b71bbb26-0643-4d1c-a86a-ba6003a77885&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

