### PR TITLE
Disable Parquet and IGV exports by default

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,7 @@ The package manual is [docs/README.md](docs/README.md).
   - `hopla transform FLOW1 FLOW2 MODE [OUTPUT]`
   - `hopla serve [--host HOST] [--port PORT] [--no-open] [--no-analysis]`
 - `vcf_file`, `out_dir`, and `cytoband_file` are CLI paths, not settings properties. Validate that supplied paths exist. `OUT_DIR` defaults to the current working directory; an omitted cytoband table is downloaded from UCSC.
-- Default `run` also writes `{family.id}-export/` Parquet and IGV sidecars unless disabled with `--no-export-parquet` / `--no-export-bigwig`.
+- `run` writes `{family.id}-export/` Parquet and IGV sidecars only when `--export-parquet` / `--export-bigwig` are given.
 - `convert` maps the legacy `key=value` settings format to schema-validated YAML.
 - Return zero for help, version, and successful commands; return status 2 for invalid usage and status 1 for runtime failures.
 - Global options are `-h`, `-V` (not `-v`), and `-L LEVEL` (`error`, `warn`, `info`, `debug`; default `info`). Use `--` to terminate option parsing. Options must precede operands. `concordance` accepts `-r` for relative comparison. `run` also accepts `-L` before its operands.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ subtools, including historical notes from the predecessor R analysis pipeline.
 - Added columnar VCF loading with cyvcf2 into shared site tables and sample-by-site NumPy matrices.
 - Added filter 1 / filter 2 masks, variant statistics, ADO/ADI, BAF, Mendelian errors, parent mapping, and Merlin haplotyping with neighbourhood voting and short-segment correction.
 - Added a self-contained offline HTML report that inlines `plotly.js`, gzip-compresses columnar payloads, and draws SVG panels lazily on scroll.
-- Added default `{family.id}-export/` Parquet tables plus BigWig / BED / SEG / `igv-session.xml` IGV desktop sidecars, with `--no-export-parquet` and `--no-export-bigwig` toggles.
+- Added optional `{family.id}-export/` Parquet tables plus BigWig / BED / SEG / `igv-session.xml` IGV desktop sidecars, enabled with `--export-parquet` and `--export-bigwig`.
 - Added `hopla serve`, a loopback-only-by-default Starlette and Jinja settings editor packaged with the Python wheel.
 - Added schema-validated YAML preview/download and legacy `.txt`, YAML, and JSON imports with pedigree reconstruction.
 - Added browser-driven analysis to `hopla serve`: it runs the current configuration with an uploaded VCF and returns a temporary self-contained HTML report, with a live step log and a `--no-analysis` flag that serves settings editing only.
@@ -21,6 +21,7 @@ subtools, including historical notes from the predecessor R analysis pipeline.
 
 ### Changed
 
+- `hopla run` writes Parquet and IGV desktop sidecars only when `--export-parquet` or `--export-bigwig` is given.
 - Replaced order-aligned pedigree arrays in generated YAML/JSON with structured
   `family.id` and `family.members` objects. Existing parallel-array settings
   are remapped when loaded; the engine also uses member-by-ID lookup directly.

--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ pixi install --locked
 pixi run hopla run example/settings.yaml path/to/family.vcf.gz
 ```
 
-By default `hopla run` also writes `{family.id}-export/` with Parquet tables and
-IGV desktop tracks. See [exports.md](docs/exports.md). Example settings and a
-legacy conversion fixture are in [`example/`](example/).
+Pass `--export-parquet` and `--export-bigwig` to also write `{family.id}-export/`
+with Parquet tables and IGV desktop tracks. See [exports.md](docs/exports.md).
+Example settings and a legacy conversion fixture are in [`example/`](example/).
 
 `hopla serve` can create or import settings, upload a VCF selected in the
 browser, run the analysis, and return its HTML report. Web runs use temporary

--- a/docs/README.md
+++ b/docs/README.md
@@ -47,8 +47,9 @@ pixi run hopla run example/settings.yaml path/to/family.vcf.gz
 ```
 
 The command validates settings before reading the VCF and writes a compact,
-offline HTML report. By default it also writes portable Parquet tables and IGV
-desktop tracks under `{family.id}-export/`. Merlin 1.1.2 remains an optional
+offline HTML report. Pass `--export-parquet` and `--export-bigwig` to also write
+portable Parquet tables and IGV desktop tracks under `{family.id}-export/`.
+Merlin 1.1.2 remains an optional
 external dependency for haplotyping. Example settings live in
 [`example/`](../example/).
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -36,9 +36,9 @@ hopla [-hV] [-L LEVEL] serve [--host HOST] [--port PORT]
   [hg38 `cytoBand.txt.gz`](https://hgdownload.soe.ucsc.edu/goldenPath/hg38/database/cytoBand.txt.gz)
   into a temporary directory for that run.
 - `--export-parquet` / `--no-export-parquet` controls writing portable Parquet
-  tables under `{family.id}-export/` (default: on).
+  tables under `{family.id}-export/` (default: off).
 - `--export-bigwig` / `--no-export-bigwig` controls writing BigWig, BED, SEG,
-  and `igv-session.xml` under the same export directory (default: on). Details:
+  and `igv-session.xml` under the same export directory (default: off). Details:
   [exports.md](exports.md).
 - `convert` maps a legacy `key=value` settings file to schema-validated YAML.
   Unsupported keys are omitted after a warning. `OUTPUT` defaults to the input
@@ -74,7 +74,7 @@ With pixi:
 pixi run hopla run path/to/settings.yaml path/to/family.vcf.gz
 pixi run hopla run -o path/to/output path/to/settings.yaml path/to/family.vcf.gz
 pixi run hopla run -c path/to/cytoband.hg38.txt path/to/settings.yaml path/to/family.vcf.gz
-pixi run hopla run --no-export-parquet --no-export-bigwig path/to/settings.yaml path/to/family.vcf.gz
+pixi run hopla run --export-parquet --export-bigwig path/to/settings.yaml path/to/family.vcf.gz
 ```
 
 With an editable install on `PATH`:

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -73,8 +73,8 @@ Details: [install.md](install.md).
 - `vcf_file`, `out_dir`, and `cytoband_file` are CLI paths, not settings
   properties. Validate that supplied paths exist. `OUT_DIR` defaults to the
   current working directory; an omitted cytoband table is downloaded from UCSC.
-- Default `run` also writes `{family.id}-export/` Parquet and IGV sidecars unless
-  disabled with `--no-export-parquet` / `--no-export-bigwig`.
+- `run` writes `{family.id}-export/` Parquet and IGV sidecars only when
+  `--export-parquet` / `--export-bigwig` are given.
 - `convert` maps the legacy `key=value` settings format to schema-validated
   YAML.
 - Return zero for help, version, and successful commands; return status 2 for

--- a/docs/exports.md
+++ b/docs/exports.md
@@ -1,7 +1,7 @@
 # Portable analysis exports
 
-`hopla run` writes `{family.id}-export/` by default. Use
-`--no-export-parquet` when only the HTML report is needed.
+Pass `--export-parquet` so `hopla run` writes `{family.id}-export/`. The HTML
+report is still written when the flag is omitted.
 
 Each visualized dataset is stored in its own Apache Parquet file with zstd
 compression. `manifest.json` records the genome, coordinate convention, row
@@ -16,7 +16,8 @@ not duplicate the input VCF.
 
 ## IGV tracks
 
-By default, the same export directory also contains:
+Pass `--export-bigwig` to write IGV desktop tracks in the same export
+directory:
 
 - one `{sample}-baf.bw` track per sample;
 - normalized copy-number and Mendelian-error BigWigs when data exists;
@@ -26,5 +27,4 @@ By default, the same export directory also contains:
 
 Open the session with IGV desktop against hg38. BigWig coordinates are
 converted to zero-based half-open intervals internally, while the Parquet
-tables retain their documented one-based inclusive coordinates. Disable track
-generation with `--no-export-bigwig`.
+tables retain their documented one-based inclusive coordinates.

--- a/docs/output.md
+++ b/docs/output.md
@@ -2,8 +2,9 @@
 
 The analysis writes an interactive HTML file (`{family.id}-output.html`). Hovering,
 dragging, and related Plotly controls manipulate the figures, and raw data can
-often be inspected. By default the same run also writes portable Parquet tables
-and IGV desktop tracks under `{family.id}-export/`; see [exports.md](exports.md).
+often be inspected. Pass `--export-parquet` and `--export-bigwig` to also write
+portable Parquet tables and IGV desktop tracks under `{family.id}-export/`; see
+[exports.md](exports.md).
 
 The report is always a single offline document: the offline `plotly.js` bundle
 is inlined once, analysis tables are serialized column-wise and gzip-compressed

--- a/docs/serve.md
+++ b/docs/serve.md
@@ -53,10 +53,10 @@ instance that should not read local VCFs or start runs cannot be driven into
 doing so.
 
 Web analyses generate only the self-contained HTML report; they do not generate
-the Parquet or IGV sidecars written by the default `hopla run` command. Use the
-CLI when those exports, a persistent output directory, or a custom cytoband
-file are required. When the web interface needs the default hg38 cytobands, the
-server downloads them as it does for `hopla run` without `-c`.
+Parquet or IGV sidecars. Use `hopla run` with `--export-parquet` /
+`--export-bigwig` when those exports, a persistent output directory, or a custom
+cytoband file are required. When the web interface needs the default hg38
+cytobands, the server downloads them as it does for `hopla run` without `-c`.
 
 ## Network safety
 

--- a/src/hopla/cli.py
+++ b/src/hopla/cli.py
@@ -102,14 +102,14 @@ def run_command(
             "--export-parquet/--no-export-parquet",
             help="Write portable Parquet tables for visualized data.",
         ),
-    ] = True,
+    ] = False,
     export_bigwig: Annotated[
         bool,
         typer.Option(
             "--export-bigwig/--no-export-bigwig",
             help="Write BigWig, BED, SEG, and an IGV desktop session.",
         ),
-    ] = True,
+    ] = False,
 ) -> None:
     """Run the complete family analysis and write its report."""
     if log_level is not None:

--- a/src/hopla/pipeline.py
+++ b/src/hopla/pipeline.py
@@ -25,8 +25,8 @@ def run_analysis(
     out_dir: Path,
     *,
     cytoband_path: Path | None = None,
-    export_parquet_data: bool = True,
-    export_bigwig: bool = True,
+    export_parquet_data: bool = False,
+    export_bigwig: bool = False,
     progress: ProgressCallback | None = None,
 ) -> Path:
     """Run an analysis and return the generated HTML report path."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -97,3 +97,37 @@ def test_run_writes_report(tmp_path: Path, family_vcf: Path, settings_file: Path
     assert "<h4>Number of variants table</h4>" in html
     assert "application/gzip+json" in html
     assert "Plotly" in html
+    assert not (tmp_path / "hopla-export").exists()
+
+
+def test_run_export_flags_write_parquet_and_igv(
+    tmp_path: Path, family_vcf: Path, settings_file: Path
+) -> None:
+    """Opt in to Parquet tables and IGV desktop sidecars from the CLI."""
+    cytobands = tmp_path / "cyto.txt"
+    cytobands.write_text(
+        "\n".join(
+            f"chr{chrom}\t0\t1000000\tp1\tgneg"
+            for chrom in [str(index) for index in range(1, 23)] + ["X"]
+        ),
+        encoding="utf-8",
+    )
+    result = runner.invoke(
+        app,
+        [
+            "run",
+            "--export-parquet",
+            "--export-bigwig",
+            "-o",
+            str(tmp_path),
+            "-c",
+            str(cytobands),
+            str(settings_file),
+            str(family_vcf),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    export_dir = tmp_path / "hopla-export"
+    assert (export_dir / "manifest.json").exists()
+    assert (export_dir / "baf.parquet").exists()
+    assert (export_dir / "igv-session.xml").exists()

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -193,8 +193,8 @@ def test_stream_vcf_run_and_download_report(
         out_dir: Path,
         *,
         cytoband_path: Path | None = None,
-        export_parquet_data: bool = True,
-        export_bigwig: bool = True,
+        export_parquet_data: bool = False,
+        export_bigwig: bool = False,
         progress: ProgressCallback | None = None,
     ) -> Path:
         del cytoband_path
@@ -280,8 +280,8 @@ def test_analysis_surfaces_pipeline_failure(monkeypatch: pytest.MonkeyPatch) -> 
         out_dir: Path,
         *,
         cytoband_path: Path | None = None,
-        export_parquet_data: bool = True,
-        export_bigwig: bool = True,
+        export_parquet_data: bool = False,
+        export_bigwig: bool = False,
         progress: ProgressCallback | None = None,
     ) -> Path:
         del (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`hopla run` now writes Parquet tables and IGV desktop sidecars only when you pass `--export-parquet` and/or `--export-bigwig`. The default run still writes the HTML report only.

`--no-export-parquet` and `--no-export-bigwig` remain valid so existing scripts that disable exports keep working.

`run_analysis()` matches that default. `hopla serve` already skipped these sidecars.

Package version stays 3.0.0.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-06ce730f-b662-4dbe-8f9a-05070435b04e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-06ce730f-b662-4dbe-8f9a-05070435b04e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

