### PR TITLE
Simplify pixi configuration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,8 +12,8 @@ The package manual is [docs/README.md](docs/README.md).
 - Keep `linux-64`, `linux-aarch64`, and `osx-arm64` supported. Merlin 1.1.2 is available on each of those platforms in the default environment.
 - Require Python 3.12 or newer.
 - Add Python dependencies to both `[project]` / `[project.optional-dependencies]` and `[tool.pixi.dependencies]` / `[tool.pixi.feature.dev.dependencies]` in `pyproject.toml`; regenerate `pixi.lock` with pixi. Conda entries override the same-named PyPI requirements from `[project]`. Keep the bioconda `conda-pypi-map` entry for `pybigwig` so osx-arm64 does not pull a PyPI source build.
-- Keep `pixi.lock` free of PyPI source dependencies. Every locked dependency is a conda package; the local package itself is not locked.
-- Prefer editable installs through `pixi run install-py` rather than unmanaged global pip installs.
+- Keep `pixi.lock` free of third-party PyPI source dependencies. Every locked third-party dependency is a conda package; the local package is the editable `[tool.pixi.pypi-dependencies]` path entry.
+- Prefer the pixi editable path install over unmanaged global pip installs.
 - Hopla must not invoke Pandoc. The report always inlines the offline `plotly.js` bundle and compresses the columnar payload itself.
 
 ## Package structure
@@ -60,7 +60,7 @@ The package manual is [docs/README.md](docs/README.md).
 ## Containers
 
 - Build `Dockerfile` from the repository-root context and `pixi.lock`.
-- Resolve every third-party dependency through `pixi install --locked`; the image then installs the local package with `pip install --no-deps .`.
+- Resolve every third-party dependency through `pixi install --locked`; the image then overlays a non-editable `pip install --no-deps --force-reinstall .` so the runtime stage does not need `src/`.
 - Do not ship the pixi binary in the runtime stage.
 
 ## Verification

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,7 @@ The package manual is [docs/README.md](docs/README.md).
 ## Containers
 
 - Build `Dockerfile` from the repository-root context and `pixi.lock`.
-- Resolve every third-party dependency through `pixi install --locked`; the image then overlays a non-editable `pip install --no-deps --force-reinstall .` so the runtime stage does not need `src/`.
+- Resolve every third-party dependency through `pixi install --locked`; after the shell hook, the image uninstalls the editable path package and overlays a non-editable `pip install --no-deps .` so the runtime stage does not need `src/`.
 - Do not ship the pixi binary in the runtime stage.
 
 ## Verification

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 This changelog covers the Hopla Python package, settings editor, and command-line
 subtools, including historical notes from the predecessor R analysis pipeline.
 
+## [Unreleased]
+
+### Changed
+
+- Installed the local package as an editable pixi path dependency, so
+  `pixi install` is enough and the `install-py` / CLI wrapper tasks are gone.
+- Locked `default` and `dev` in one solve group. The image still overlays a
+  non-editable `pip install` so the runtime stage does not need `src/`.
+
 ## [3.0.0] - 2026-08-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ subtools, including historical notes from the predecessor R analysis pipeline.
 
 - Installed the local package as an editable pixi path dependency, so
   `pixi install` is enough and the `install-py` / CLI wrapper tasks are gone.
-- Locked `default` and `dev` in one solve group. The image still overlays a
-  non-editable `pip install` so the runtime stage does not need `src/`.
+- Locked `default` and `dev` in one solve group. After the shell hook, the
+  image replaces the editable path install with a non-editable `pip install`
+  so the runtime stage does not need `src/`.
 
 ## [3.0.0] - 2026-08-28
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,11 @@ WORKDIR /app
 COPY pixi.lock pyproject.toml LICENSE README.md ./
 COPY src ./src
 RUN pixi install --locked \
-    && pixi run python -m pip install --no-deps --force-reinstall . \
     && pixi shell-hook -s bash > /app/entrypoint.sh \
     && printf '\nexec "$@"\n' >> /app/entrypoint.sh \
-    && chmod 0755 /app/entrypoint.sh
+    && chmod 0755 /app/entrypoint.sh \
+    && /app/.pixi/envs/default/bin/python -m pip uninstall -y hopla \
+    && /app/.pixi/envs/default/bin/python -m pip install --no-deps .
 
 FROM ubuntu:24.04 AS production
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 COPY pixi.lock pyproject.toml LICENSE README.md ./
 COPY src ./src
 RUN pixi install --locked \
-    && pixi run python -m pip install --no-deps . \
+    && pixi run python -m pip install --no-deps --force-reinstall . \
     && pixi shell-hook -s bash > /app/entrypoint.sh \
     && printf '\nexec "$@"\n' >> /app/entrypoint.sh \
     && chmod 0755 /app/entrypoint.sh

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -19,10 +19,10 @@ An agent-discoverable copy of this material lives in
   the same-named PyPI requirements from `[project]`. Keep the bioconda
   `conda-pypi-map` entry for `pybigwig` so osx-arm64 does not pull a PyPI
   source build.
-- Keep `pixi.lock` free of PyPI source dependencies. Every locked dependency
-  is a conda package; the local package itself is not locked.
-- Prefer editable installs through `pixi run install-py` rather than unmanaged
-  global pip installs.
+- Keep `pixi.lock` free of third-party PyPI source dependencies. Every locked
+  third-party dependency is a conda package; the local package is the
+  editable `[tool.pixi.pypi-dependencies]` path entry.
+- Prefer the pixi editable path install over unmanaged global pip installs.
 - Hopla must not invoke Pandoc. The report always inlines the offline
   `plotly.js` bundle and compresses the columnar payload itself.
 
@@ -97,7 +97,9 @@ Details: [install.md](install.md).
 
 - Build `Dockerfile` from the repository-root context and `pixi.lock`.
 - Resolve every third-party dependency through `pixi install --locked`; the
-  image then installs the local package with `pip install --no-deps .`.
+  image then overlays a non-editable
+  `pip install --no-deps --force-reinstall .` so the runtime stage does not
+  need `src/`.
 - Do not ship the pixi binary in the runtime stage.
 
 ## Verification

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -97,8 +97,8 @@ Details: [install.md](install.md).
 
 - Build `Dockerfile` from the repository-root context and `pixi.lock`.
 - Resolve every third-party dependency through `pixi install --locked`; the
-  image then overlays a non-editable
-  `pip install --no-deps --force-reinstall .` so the runtime stage does not
+  image then uninstalls the editable path package and overlays a
+  non-editable `pip install --no-deps .` so the runtime stage does not
   need `src/`.
 - Do not ship the pixi binary in the runtime stage.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -11,28 +11,23 @@ of those platforms in the default environment.
 
 ```bash
 pixi install --locked
-pixi run install-py
 pixi run hopla --help
 ```
 
-Use `pixi install --locked` so the committed `pixi.lock` is respected. The lock
-holds conda packages only; the local package is installed on top of it with an
-editable pip install.
+Use `pixi install --locked` so the committed `pixi.lock` is respected. Third-party
+lock entries are conda packages; the local package is the editable pixi path
+dependency, so `pixi install` puts `hopla` on the environment `PATH`.
 
 The default environment holds analysis dependencies and Merlin. The `dev`
 environment adds pytest, ruff, mypy, and typing stubs.
 
 Pixi tasks (from the repository root):
 
-- default environment `install-py` — editable install with
-  `python -m pip install --no-deps -e .`
-- default environment `hopla`, `serve`, `convert`, `concordance`, and
-  `transform` — installed Python CLI entry points (depend on `install-py`)
 - `dev` environment `lint-py` — `ruff check` and `mypy`
 - `dev` environment `test-py` — `pytest tests`
 
-After the editable install, the `hopla` console script is also available on the
-environment `PATH`.
+After install, `pixi run hopla` invokes the console script (for example
+`pixi run hopla convert` or `pixi run hopla serve`).
 
 ## Pip (development tree)
 
@@ -85,6 +80,6 @@ columnar analysis payload for the browser to expand with
 Prefer adding Python dependencies in `pyproject.toml` under both `[project]`
 and `[tool.pixi.dependencies]` (or the `dev` extra / `[tool.pixi.feature.dev]`),
 then regenerate `pixi.lock` with pixi. Keep those dependencies available as
-conda packages so the lock stays free of PyPI source builds.
+conda packages so the lock stays free of third-party PyPI source builds.
 
 See [CHANGELOG.md](../CHANGELOG.md) for changes to the Python engine.

--- a/pixi.lock
+++ b/pixi.lock
@@ -22,6 +22,8 @@ environments:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
     - url: https://conda.anaconda.org/bioconda/
+    indexes:
+    - https://pypi.org/simple
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/bioconda/linux-64/cyvcf2-0.34.0-py313hd6fac57_0.conda
@@ -165,6 +167,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.16.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/uvicorn-0.52.4-pyhc90fa1f_0.conda
+      - pypi: ./
       linux-aarch64:
       - conda: https://conda.anaconda.org/bioconda/linux-aarch64/cyvcf2-0.34.0-py313h56f738b_0.conda
       - conda: https://conda.anaconda.org/bioconda/linux-aarch64/htslib-1.23.1-h58d2225_0.conda
@@ -307,6 +310,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.16.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/uvicorn-0.52.4-pyhc90fa1f_0.conda
+      - pypi: ./
       osx-arm64:
       - conda: https://conda.anaconda.org/bioconda/osx-arm64/cyvcf2-0.34.0-py313he3ac920_0.conda
       - conda: https://conda.anaconda.org/bioconda/osx-arm64/htslib-1.23.1-h44a9eb5_0.conda
@@ -444,10 +448,13 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h74c22ad_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.3.2-h8088a28_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hf451053_7.conda
+      - pypi: ./
   dev:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
     - url: https://conda.anaconda.org/bioconda/
+    indexes:
+    - https://pypi.org/simple
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/bioconda/linux-64/cyvcf2-0.34.0-py313hd6fac57_0.conda
@@ -607,6 +614,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.16.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/uvicorn-0.52.4-pyhc90fa1f_0.conda
+      - pypi: ./
       linux-aarch64:
       - conda: https://conda.anaconda.org/bioconda/linux-aarch64/cyvcf2-0.34.0-py313h56f738b_0.conda
       - conda: https://conda.anaconda.org/bioconda/linux-aarch64/htslib-1.23.1-h58d2225_0.conda
@@ -765,6 +773,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.16.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/uvicorn-0.52.4-pyhc90fa1f_0.conda
+      - pypi: ./
       osx-arm64:
       - conda: https://conda.anaconda.org/bioconda/osx-arm64/cyvcf2-0.34.0-py313he3ac920_0.conda
       - conda: https://conda.anaconda.org/bioconda/osx-arm64/htslib-1.23.1-h44a9eb5_0.conda
@@ -918,6 +927,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h74c22ad_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.3.2-h8088a28_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hf451053_7.conda
+      - pypi: ./
 packages:
 - conda: https://conda.anaconda.org/bioconda/linux-64/cyvcf2-0.34.0-py313hd6fac57_0.conda
   sha256: cc4f8444289d38cea223f8f83cddd8e7270b4a9c3764e7c60f1d06f4d7a7affe
@@ -6926,3 +6936,26 @@ packages:
     - zstd >=1.5.7,<1.6.0a0
   size: 433687
   timestamp: 1786599629846
+- pypi: ./
+  name: hopla
+  requires_dist:
+  - cyvcf2
+  - jsonschema
+  - jinja2
+  - numpy
+  - plotly
+  - polars
+  - pydantic>=2
+  - pyarrow
+  - pybigwig
+  - pyyaml
+  - starlette
+  - typer
+  - uvicorn
+  - httpx2 ; extra == 'dev'
+  - mypy ; extra == 'dev'
+  - pytest ; extra == 'dev'
+  - ruff ; extra == 'dev'
+  - types-jsonschema ; extra == 'dev'
+  - types-pyyaml ; extra == 'dev'
+  requires_python: '>=3.12'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,9 @@ channels = ["conda-forge", "bioconda"]
 platforms = ["linux-64", "linux-aarch64", "osx-arm64"]
 conda-pypi-map = { bioconda = { mapping = { pybigwig = "pybigwig" } } }
 
+[tool.pixi.pypi-dependencies]
+hopla = { path = ".", editable = true }
+
 [tool.pixi.dependencies]
 python = ">=3.12,<3.14"
 cyvcf2 = "*"
@@ -101,17 +104,10 @@ types-pyyaml = "*"
 types-jsonschema = "*"
 httpx2 = ">=2.12.0,<3"
 
-[tool.pixi.tasks]
-install-py = { cmd = "python -m pip install --no-deps -e ." }
-hopla = { cmd = "hopla", depends-on = ["install-py"] }
-convert = { cmd = "hopla convert", depends-on = ["install-py"] }
-concordance = { cmd = "hopla concordance", depends-on = ["install-py"] }
-transform = { cmd = "hopla transform", depends-on = ["install-py"] }
-serve = { cmd = "hopla serve", depends-on = ["install-py"] }
-
 [tool.pixi.feature.dev.tasks]
-lint-py = { cmd = "ruff check src tests && mypy src", depends-on = ["install-py"] }
-test-py = { cmd = "pytest tests", depends-on = ["install-py"] }
+lint-py = "ruff check src tests && mypy src"
+test-py = "pytest tests"
 
 [tool.pixi.environments]
-dev = ["dev"]
+default = { features = [], solve-group = "default" }
+dev = { features = ["dev"], solve-group = "default" }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Install the local package as an editable pixi path dependency so `pixi install` is enough; drop `install-py` and the CLI wrapper tasks.
- Lock `default` and `dev` in one solve group. Third-party lock entries stay conda; only `hopla` is the `pypi: ./` path package.
- After `pixi shell-hook`, the image uninstalls the editable path package and overlays a non-editable `pip install --no-deps .` so the runtime stage does not need `src/`.

## Verification

- `pixi install --locked` then `pixi run hopla -V` → `v3.0.0` (no extra pip install)
- `pixi run -e dev lint-py` and `pixi run -e dev test-py` (35 passed)
- Wheel build succeeds
- CI: lint/test package and Docker image (`hopla -V`) both green

## Test plan

- [x] `pixi install --locked` then `pixi run hopla -V` without a prior pip install
- [x] `pixi run -e dev lint-py` and `pixi run -e dev test-py`
- [x] `pixi run -e dev python -m pip wheel --no-deps . -w dist`
- [x] Docker build and `docker run --rm hopla:<tag> hopla -V` (CI)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eaa16087-7296-4c53-892e-ce24b48187c3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eaa16087-7296-4c53-892e-ce24b48187c3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

