### PR TITLE
Replace Merlin subprocesses with merlinpy

### DIFF
--- a/.github/workflows/python-ci.yaml
+++ b/.github/workflows/python-ci.yaml
@@ -33,6 +33,13 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
+        with:
+          path: hopla
+
+      - uses: actions/checkout@v4
+        with:
+          repository: matthdsm/abecasis-lab-merlin
+          path: abecasis-lab-merlin
 
       - uses: prefix-dev/setup-pixi@v0.9.3
         with:
@@ -40,33 +47,44 @@ jobs:
           cache: true
           locked: true
           environments: dev
+          manifest-path: hopla/pyproject.toml
 
       - name: Lint and type-check
         run: pixi run -e dev lint-py
+        working-directory: hopla
 
       - name: Test
         run: pixi run -e dev test-py
+        working-directory: hopla
 
       - name: Build wheel
         run: pixi run -e dev python -m pip wheel --no-deps . -w dist
+        working-directory: hopla
 
       - name: Upload Python wheel artifact
         uses: actions/upload-artifact@v4
         with:
           name: hopla-python-wheel
-          path: dist/*.whl
+          path: hopla/dist/*.whl
 
       - name: Attach Python wheel to release
         if: github.event_name == 'release'
         uses: softprops/action-gh-release@v2
         with:
-          files: dist/*.whl
+          files: hopla/dist/*.whl
 
   image:
     name: Build and publish Python image
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
+        with:
+          path: hopla
+
+      - uses: actions/checkout@v4
+        with:
+          repository: matthdsm/abecasis-lab-merlin
+          path: abecasis-lab-merlin
 
       - uses: docker/setup-buildx-action@v3
 
@@ -74,7 +92,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: "."
-          file: Dockerfile
+          file: hopla/Dockerfile
           load: true
           tags: hopla:${{ github.sha }}
           cache-from: type=gha
@@ -85,14 +103,14 @@ jobs:
 
       - name: Save Docker image artifact
         run: |
-          mkdir -p dist
-          docker save hopla:${GITHUB_SHA} | gzip -9 > dist/hopla-image-linux-64.tar.gz
+          mkdir -p hopla/dist
+          docker save hopla:${GITHUB_SHA} | gzip -9 > hopla/dist/hopla-image-linux-64.tar.gz
 
       - name: Upload Docker image artifact
         uses: actions/upload-artifact@v4
         with:
           name: hopla-docker-image
-          path: dist/hopla-image-linux-64.tar.gz
+          path: hopla/dist/hopla-image-linux-64.tar.gz
 
       - name: Log in to Quay
         if: github.event_name != 'pull_request'
@@ -109,7 +127,7 @@ jobs:
         run: |
           tags=("$IMAGE:${GITHUB_SHA}")
           if [[ "${GITHUB_EVENT_NAME}" == "release" ]]; then
-            package_version="$(sed -n 's/^version = "\(.*\)"/\1/p' pyproject.toml | head -n1)"
+            package_version="$(sed -n 's/^version = "\(.*\)"/\1/p' hopla/pyproject.toml | head -n1)"
             tags+=("$IMAGE:${package_version}" "$IMAGE:stable")
           else
             tags+=("$IMAGE:latest")
@@ -123,4 +141,4 @@ jobs:
         if: github.event_name == 'release'
         uses: softprops/action-gh-release@v2
         with:
-          files: dist/hopla-image-linux-64.tar.gz
+          files: hopla/dist/hopla-image-linux-64.tar.gz

--- a/.github/workflows/python-ci.yaml
+++ b/.github/workflows/python-ci.yaml
@@ -11,6 +11,8 @@ on:
       - "pixi.lock"
       - "Dockerfile"
       - ".github/workflows/python-ci.yaml"
+      - ".gitmodules"
+      - "vendor/abecasis-lab-merlin"
   push:
     branches: [main, master]
     paths:
@@ -21,6 +23,8 @@ on:
       - "pixi.lock"
       - "Dockerfile"
       - ".github/workflows/python-ci.yaml"
+      - ".gitmodules"
+      - "vendor/abecasis-lab-merlin"
   release:
     types: [published]
 
@@ -34,12 +38,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          path: hopla
-
-      - uses: actions/checkout@v4
-        with:
-          repository: matthdsm/abecasis-lab-merlin
-          path: abecasis-lab-merlin
+          submodules: true
 
       - uses: prefix-dev/setup-pixi@v0.9.3
         with:
@@ -47,31 +46,27 @@ jobs:
           cache: true
           locked: true
           environments: dev
-          manifest-path: hopla/pyproject.toml
 
       - name: Lint and type-check
         run: pixi run -e dev lint-py
-        working-directory: hopla
 
       - name: Test
         run: pixi run -e dev test-py
-        working-directory: hopla
 
       - name: Build wheel
         run: pixi run -e dev python -m pip wheel --no-deps . -w dist
-        working-directory: hopla
 
       - name: Upload Python wheel artifact
         uses: actions/upload-artifact@v4
         with:
           name: hopla-python-wheel
-          path: hopla/dist/*.whl
+          path: dist/*.whl
 
       - name: Attach Python wheel to release
         if: github.event_name == 'release'
         uses: softprops/action-gh-release@v2
         with:
-          files: hopla/dist/*.whl
+          files: dist/*.whl
 
   image:
     name: Build and publish Python image
@@ -79,12 +74,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          path: hopla
-
-      - uses: actions/checkout@v4
-        with:
-          repository: matthdsm/abecasis-lab-merlin
-          path: abecasis-lab-merlin
+          submodules: true
 
       - uses: docker/setup-buildx-action@v3
 
@@ -92,7 +82,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: "."
-          file: hopla/Dockerfile
+          file: Dockerfile
           load: true
           tags: hopla:${{ github.sha }}
           cache-from: type=gha
@@ -103,14 +93,14 @@ jobs:
 
       - name: Save Docker image artifact
         run: |
-          mkdir -p hopla/dist
-          docker save hopla:${GITHUB_SHA} | gzip -9 > hopla/dist/hopla-image-linux-64.tar.gz
+          mkdir -p dist
+          docker save hopla:${GITHUB_SHA} | gzip -9 > dist/hopla-image-linux-64.tar.gz
 
       - name: Upload Docker image artifact
         uses: actions/upload-artifact@v4
         with:
           name: hopla-docker-image
-          path: hopla/dist/hopla-image-linux-64.tar.gz
+          path: dist/hopla-image-linux-64.tar.gz
 
       - name: Log in to Quay
         if: github.event_name != 'pull_request'
@@ -127,7 +117,7 @@ jobs:
         run: |
           tags=("$IMAGE:${GITHUB_SHA}")
           if [[ "${GITHUB_EVENT_NAME}" == "release" ]]; then
-            package_version="$(sed -n 's/^version = "\(.*\)"/\1/p' hopla/pyproject.toml | head -n1)"
+            package_version="$(sed -n 's/^version = "\(.*\)"/\1/p' pyproject.toml | head -n1)"
             tags+=("$IMAGE:${package_version}" "$IMAGE:stable")
           else
             tags+=("$IMAGE:latest")
@@ -141,4 +131,4 @@ jobs:
         if: github.event_name == 'release'
         uses: softprops/action-gh-release@v2
         with:
-          files: hopla/dist/hopla-image-linux-64.tar.gz
+          files: dist/hopla-image-linux-64.tar.gz

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 !pixi.lock
 .pixi/
 *merlin
+!vendor/abecasis-lab-merlin
+!vendor/abecasis-lab-merlin/**
 *.html
 !src/hopla/ui/templates/index.html
 .DS_Store

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "vendor/abecasis-lab-merlin"]
+	path = vendor/abecasis-lab-merlin
+	url = https://github.com/bioinformaticsorphanage/abecasis-lab-merlin.git
+	branch = main

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,10 +9,10 @@ The package manual is [docs/README.md](docs/README.md).
 ## Runtime and dependencies
 
 - Use the root pixi environments (`default` and `dev`) and the committed `pixi.lock`.
-- Keep `linux-64`, `linux-aarch64`, and `osx-arm64` supported. The sibling `../abecasis-lab-merlin` repository supplies the editable `merlinpy` dependency in each environment.
+- Keep `linux-64`, `linux-aarch64`, and `osx-arm64` supported. The `vendor/abecasis-lab-merlin` git submodule supplies the editable `merlinpy` dependency in each environment.
 - Require Python 3.12 or newer.
 - Add Python dependencies to `[project]` / `[project.optional-dependencies]` and the matching pixi conda or PyPI dependency section in `pyproject.toml`; regenerate `pixi.lock` with pixi. Conda entries override the same-named PyPI requirements from `[project]`. Keep the bioconda `conda-pypi-map` entry for `pybigwig` so osx-arm64 does not pull a PyPI source build.
-- Keep `pixi.lock` free of third-party PyPI source dependencies except for the editable `merlinpy` sibling path. The local Hopla package is the other editable `[tool.pixi.pypi-dependencies]` path entry.
+- Keep `pixi.lock` free of third-party PyPI source dependencies except for the editable `merlinpy` submodule path. The local Hopla package is the other editable `[tool.pixi.pypi-dependencies]` path entry.
 - Prefer the pixi editable path install over unmanaged global pip installs.
 - Hopla must not invoke Pandoc. The report always inlines the offline `plotly.js` bundle and compresses the columnar payload itself.
 
@@ -59,8 +59,8 @@ The package manual is [docs/README.md](docs/README.md).
 
 ## Containers
 
-- Build `hopla/Dockerfile` from the parent context containing sibling `hopla/` and `abecasis-lab-merlin/` checkouts.
-- Resolve dependencies through `pixi install --locked`; after the shell hook, the image replaces both editable path packages with non-editable `pip install --no-deps` installs so the runtime stage does not need either source tree.
+- Build `Dockerfile` from the repository-root context and `pixi.lock`, including the `vendor/abecasis-lab-merlin` submodule.
+- Resolve every third-party dependency through `pixi install --locked`; after the shell hook, the image uninstalls the editable path packages and overlays non-editable `pip install --no-deps` installs of `merlinpy` and Hopla so the runtime stage does not need `src/` or the submodule tree.
 - Do not ship the pixi binary in the runtime stage.
 
 ## Verification

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,10 +9,10 @@ The package manual is [docs/README.md](docs/README.md).
 ## Runtime and dependencies
 
 - Use the root pixi environments (`default` and `dev`) and the committed `pixi.lock`.
-- Keep `linux-64`, `linux-aarch64`, and `osx-arm64` supported. Merlin 1.1.2 is available on each of those platforms in the default environment.
+- Keep `linux-64`, `linux-aarch64`, and `osx-arm64` supported. The sibling `../abecasis-lab-merlin` repository supplies the editable `merlinpy` dependency in each environment.
 - Require Python 3.12 or newer.
-- Add Python dependencies to both `[project]` / `[project.optional-dependencies]` and `[tool.pixi.dependencies]` / `[tool.pixi.feature.dev.dependencies]` in `pyproject.toml`; regenerate `pixi.lock` with pixi. Conda entries override the same-named PyPI requirements from `[project]`. Keep the bioconda `conda-pypi-map` entry for `pybigwig` so osx-arm64 does not pull a PyPI source build.
-- Keep `pixi.lock` free of third-party PyPI source dependencies. Every locked third-party dependency is a conda package; the local package is the editable `[tool.pixi.pypi-dependencies]` path entry.
+- Add Python dependencies to `[project]` / `[project.optional-dependencies]` and the matching pixi conda or PyPI dependency section in `pyproject.toml`; regenerate `pixi.lock` with pixi. Conda entries override the same-named PyPI requirements from `[project]`. Keep the bioconda `conda-pypi-map` entry for `pybigwig` so osx-arm64 does not pull a PyPI source build.
+- Keep `pixi.lock` free of third-party PyPI source dependencies except for the editable `merlinpy` sibling path. The local Hopla package is the other editable `[tool.pixi.pypi-dependencies]` path entry.
 - Prefer the pixi editable path install over unmanaged global pip installs.
 - Hopla must not invoke Pandoc. The report always inlines the offline `plotly.js` bundle and compresses the columnar payload itself.
 
@@ -59,8 +59,8 @@ The package manual is [docs/README.md](docs/README.md).
 
 ## Containers
 
-- Build `Dockerfile` from the repository-root context and `pixi.lock`.
-- Resolve every third-party dependency through `pixi install --locked`; after the shell hook, the image uninstalls the editable path package and overlays a non-editable `pip install --no-deps .` so the runtime stage does not need `src/`.
+- Build `hopla/Dockerfile` from the parent context containing sibling `hopla/` and `abecasis-lab-merlin/` checkouts.
+- Resolve dependencies through `pixi install --locked`; after the shell hook, the image replaces both editable path packages with non-editable `pip install --no-deps` installs so the runtime stage does not need either source tree.
 - Do not ship the pixi binary in the runtime stage.
 
 ## Verification

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ subtools, including historical notes from the predecessor R analysis pipeline.
 ### Changed
 
 - Replaced native `merlin` / `minx` subprocesses with in-process calls to the
-  sibling `merlinpy` package. Merlin no longer needs to be on `$PATH`.
+  `merlinpy` package from the `vendor/abecasis-lab-merlin` git submodule.
+  Merlin no longer needs to be on `$PATH`.
 - The `sample` Merlin model is supported only for zero-bit families by
   `merlinpy`; informative pedigrees fail with an explicit error. The default
   `best` model remains supported.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ subtools, including historical notes from the predecessor R analysis pipeline.
 
 ## [Unreleased]
 
+### Changed
+
+- Replaced native `merlin` / `minx` subprocesses with in-process calls to the
+  sibling `merlinpy` package. Merlin no longer needs to be on `$PATH`.
+- The `sample` Merlin model is supported only for zero-bit families by
+  `merlinpy`; informative pedigrees fail with an explicit error. The default
+  `best` model remains supported.
+
 ## [3.0.0] - 2026-08-28
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,23 @@
 FROM ghcr.io/prefix-dev/pixi:0.77.1 AS build
 
 WORKDIR /app
-COPY abecasis-lab-merlin ./abecasis-lab-merlin
-COPY hopla ./hopla
-WORKDIR /app/hopla
+COPY pixi.lock pyproject.toml LICENSE README.md ./
+COPY src ./src
+COPY vendor/abecasis-lab-merlin ./vendor/abecasis-lab-merlin
 RUN pixi install --locked \
     && pixi shell-hook -s bash > /app/entrypoint.sh \
     && printf '\nexec "$@"\n' >> /app/entrypoint.sh \
     && chmod 0755 /app/entrypoint.sh \
-    && /app/hopla/.pixi/envs/default/bin/python -m pip uninstall -y hopla merlinpy \
-    && /app/hopla/.pixi/envs/default/bin/python -m pip install \
-        --no-deps ../abecasis-lab-merlin \
-    && /app/hopla/.pixi/envs/default/bin/python -m pip install --no-deps .
+    && /app/.pixi/envs/default/bin/python -m pip uninstall -y hopla merlinpy \
+    && /app/.pixi/envs/default/bin/python -m pip install --no-deps ./vendor/abecasis-lab-merlin \
+    && /app/.pixi/envs/default/bin/python -m pip install --no-deps .
 
 FROM ubuntu:24.04 AS production
 
 WORKDIR /app
-COPY --from=build /app/hopla/.pixi/envs/default /app/hopla/.pixi/envs/default
+COPY --from=build /app/.pixi/envs/default /app/.pixi/envs/default
 COPY --from=build /app/entrypoint.sh /app/entrypoint.sh
-RUN printf '#!/bin/sh\nexec /app/hopla/.pixi/envs/default/bin/hopla "$@"\n' \
+RUN printf '#!/bin/sh\nexec /app/.pixi/envs/default/bin/hopla "$@"\n' \
     > /usr/local/bin/hopla \
     && chmod 0755 /usr/local/bin/hopla
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,24 @@
 FROM ghcr.io/prefix-dev/pixi:0.77.1 AS build
 
 WORKDIR /app
-COPY pixi.lock pyproject.toml LICENSE README.md ./
-COPY src ./src
+COPY abecasis-lab-merlin ./abecasis-lab-merlin
+COPY hopla ./hopla
+WORKDIR /app/hopla
 RUN pixi install --locked \
     && pixi shell-hook -s bash > /app/entrypoint.sh \
     && printf '\nexec "$@"\n' >> /app/entrypoint.sh \
     && chmod 0755 /app/entrypoint.sh \
-    && /app/.pixi/envs/default/bin/python -m pip uninstall -y hopla \
-    && /app/.pixi/envs/default/bin/python -m pip install --no-deps .
+    && /app/hopla/.pixi/envs/default/bin/python -m pip uninstall -y hopla merlinpy \
+    && /app/hopla/.pixi/envs/default/bin/python -m pip install \
+        --no-deps ../abecasis-lab-merlin \
+    && /app/hopla/.pixi/envs/default/bin/python -m pip install --no-deps .
 
 FROM ubuntu:24.04 AS production
 
 WORKDIR /app
-COPY --from=build /app/.pixi/envs/default /app/.pixi/envs/default
+COPY --from=build /app/hopla/.pixi/envs/default /app/hopla/.pixi/envs/default
 COPY --from=build /app/entrypoint.sh /app/entrypoint.sh
-RUN printf '#!/bin/sh\nexec /app/.pixi/envs/default/bin/hopla "$@"\n' \
+RUN printf '#!/bin/sh\nexec /app/hopla/.pixi/envs/default/bin/hopla "$@"\n' \
     > /usr/local/bin/hopla \
     && chmod 0755 /usr/local/bin/hopla
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This repository holds the typed Python package `hopla` (version 3.0.0).
 ## Quick start
 
 ```bash
-git clone https://github.com/CenterForMedicalGeneticsGhent/Hopla
+git clone --recurse-submodules https://github.com/CenterForMedicalGeneticsGhent/Hopla
 cd Hopla
 pixi install --locked
 pixi run hopla run example/settings.yaml path/to/family.vcf.gz

--- a/docs/README.md
+++ b/docs/README.md
@@ -39,8 +39,11 @@ This manual documents the Python package at the repository root. Start from the
 ## Quick start
 
 ```bash
-git clone https://github.com/CenterForMedicalGeneticsGhent/Hopla
-cd Hopla
+mkdir hopla-workspace
+cd hopla-workspace
+git clone https://github.com/CenterForMedicalGeneticsGhent/Hopla hopla
+git clone https://github.com/matthdsm/abecasis-lab-merlin
+cd hopla
 pixi install --locked
 pixi run hopla run example/settings.yaml path/to/family.vcf.gz
 ```
@@ -48,9 +51,8 @@ pixi run hopla run example/settings.yaml path/to/family.vcf.gz
 The command validates settings before reading the VCF and writes a compact,
 offline HTML report. Pass `--export-parquet` and `--export-bigwig` to also write
 portable Parquet tables and IGV desktop tracks under `{family.id}-export/`.
-Merlin 1.1.2 remains an optional
-external dependency for haplotyping. Example settings live in
-[`example/`](../example/).
+The sibling Merlin repository supplies the in-process `merlinpy` haplotyping
+dependency. Example settings live in [`example/`](../example/).
 
 Alternatively, run `pixi run hopla serve` to create or import settings, select
 a VCF in the browser, and download the generated HTML report.

--- a/docs/README.md
+++ b/docs/README.md
@@ -39,11 +39,8 @@ This manual documents the Python package at the repository root. Start from the
 ## Quick start
 
 ```bash
-mkdir hopla-workspace
-cd hopla-workspace
-git clone https://github.com/CenterForMedicalGeneticsGhent/Hopla hopla
-git clone https://github.com/matthdsm/abecasis-lab-merlin
-cd hopla
+git clone --recurse-submodules https://github.com/CenterForMedicalGeneticsGhent/Hopla
+cd Hopla
 pixi install --locked
 pixi run hopla run example/settings.yaml path/to/family.vcf.gz
 ```
@@ -51,8 +48,9 @@ pixi run hopla run example/settings.yaml path/to/family.vcf.gz
 The command validates settings before reading the VCF and writes a compact,
 offline HTML report. Pass `--export-parquet` and `--export-bigwig` to also write
 portable Parquet tables and IGV desktop tracks under `{family.id}-export/`.
-The sibling Merlin repository supplies the in-process `merlinpy` haplotyping
-dependency. Example settings live in [`example/`](../example/).
+The `vendor/abecasis-lab-merlin` git submodule supplies the in-process
+`merlinpy` haplotyping dependency. Example settings live in
+[`example/`](../example/).
 
 Alternatively, run `pixi run hopla serve` to create or import settings, select
 a VCF in the browser, and download the generated HTML report.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -52,9 +52,9 @@ The Python engine is explicit and columnar:
    sidecars. See [exports.md](exports.md).
 
 All functions are typed and documented. Polars owns tabular joins and
-aggregation; NumPy owns dense genotype operations. Merlin 1.1.2 remains an
-external executable so its haplotyping inference stays compatible with prior
-Hopla Merlin workflows.
+aggregation; NumPy owns dense genotype operations. Hopla calls the validated
+Merlin 1.1.2-compatible `merlinpy` API in-process for error detection and
+haplotyping.
 
 `cli.py` owns command-line parsing and logging setup. `pipeline.py` owns the
 shared analysis sequence, temporary cytoband download lifetime, and output

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -10,17 +10,17 @@ An agent-discoverable copy of this material lives in
 
 - Use the root pixi environments (`default` and `dev`) and the committed
   `pixi.lock`.
-- Keep `linux-64`, `linux-aarch64`, and `osx-arm64` supported. Merlin 1.1.2 is
-  available on each of those platforms in the default environment.
+- Keep `linux-64`, `linux-aarch64`, and `osx-arm64` supported. The sibling
+  `../abecasis-lab-merlin` repository supplies the editable `merlinpy`
+  dependency in each environment.
 - Require Python 3.12 or newer.
 - Add Python dependencies to both `[project]` / `[project.optional-dependencies]`
-  and `[tool.pixi.dependencies]` / `[tool.pixi.feature.dev.dependencies]` in
-  `pyproject.toml`; regenerate `pixi.lock` with pixi. Conda entries override
-  the same-named PyPI requirements from `[project]`. Keep the bioconda
-  `conda-pypi-map` entry for `pybigwig` so osx-arm64 does not pull a PyPI
-  source build.
-- Keep `pixi.lock` free of third-party PyPI source dependencies. Every locked
-  third-party dependency is a conda package; the local package is the
+  and the matching pixi conda or PyPI dependency section in `pyproject.toml`;
+  regenerate `pixi.lock` with pixi. Conda entries override the same-named PyPI
+  requirements from `[project]`. Keep the bioconda `conda-pypi-map` entry for
+  `pybigwig` so osx-arm64 does not pull a PyPI source build.
+- Keep `pixi.lock` free of third-party PyPI source dependencies except for the
+  editable `merlinpy` sibling path. The local Hopla package is the other
   editable `[tool.pixi.pypi-dependencies]` path entry.
 - Prefer the pixi editable path install over unmanaged global pip installs.
 - Hopla must not invoke Pandoc. The report always inlines the offline
@@ -95,11 +95,12 @@ Details: [install.md](install.md).
 
 ## Containers
 
-- Build `Dockerfile` from the repository-root context and `pixi.lock`.
-- Resolve every third-party dependency through `pixi install --locked`; the
-  image then uninstalls the editable path package and overlays a
-  non-editable `pip install --no-deps .` so the runtime stage does not
-  need `src/`.
+- Build `hopla/Dockerfile` from the parent context containing sibling `hopla/`
+  and `abecasis-lab-merlin/` checkouts.
+- Resolve dependencies through `pixi install --locked`; after the shell hook,
+  the image replaces both editable path packages with non-editable
+  `pip install --no-deps` installs so the runtime stage does not need either
+  source tree.
 - Do not ship the pixi binary in the runtime stage.
 
 ## Verification

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -10,8 +10,8 @@ An agent-discoverable copy of this material lives in
 
 - Use the root pixi environments (`default` and `dev`) and the committed
   `pixi.lock`.
-- Keep `linux-64`, `linux-aarch64`, and `osx-arm64` supported. The sibling
-  `../abecasis-lab-merlin` repository supplies the editable `merlinpy`
+- Keep `linux-64`, `linux-aarch64`, and `osx-arm64` supported. The
+  `vendor/abecasis-lab-merlin` git submodule supplies the editable `merlinpy`
   dependency in each environment.
 - Require Python 3.12 or newer.
 - Add Python dependencies to both `[project]` / `[project.optional-dependencies]`
@@ -20,7 +20,7 @@ An agent-discoverable copy of this material lives in
   requirements from `[project]`. Keep the bioconda `conda-pypi-map` entry for
   `pybigwig` so osx-arm64 does not pull a PyPI source build.
 - Keep `pixi.lock` free of third-party PyPI source dependencies except for the
-  editable `merlinpy` sibling path. The local Hopla package is the other
+  editable `merlinpy` submodule path. The local Hopla package is the other
   editable `[tool.pixi.pypi-dependencies]` path entry.
 - Prefer the pixi editable path install over unmanaged global pip installs.
 - Hopla must not invoke Pandoc. The report always inlines the offline
@@ -95,12 +95,12 @@ Details: [install.md](install.md).
 
 ## Containers
 
-- Build `hopla/Dockerfile` from the parent context containing sibling `hopla/`
-  and `abecasis-lab-merlin/` checkouts.
-- Resolve dependencies through `pixi install --locked`; after the shell hook,
-  the image replaces both editable path packages with non-editable
-  `pip install --no-deps` installs so the runtime stage does not need either
-  source tree.
+- Build `Dockerfile` from the repository-root context and `pixi.lock`, including
+  the `vendor/abecasis-lab-merlin` submodule.
+- Resolve every third-party dependency through `pixi install --locked`; after
+  the shell hook, the image uninstalls the editable path packages and overlays
+  non-editable `pip install --no-deps` installs of `merlinpy` and Hopla so the
+  runtime stage does not need `src/` or the submodule tree.
 - Do not ship the pixi binary in the runtime stage.
 
 ## Verification

--- a/docs/install.md
+++ b/docs/install.md
@@ -6,20 +6,28 @@ environment).
 ## Pixi (Linux and macOS)
 
 The repository includes a locked [pixi](https://pixi.sh) environment for
-`linux-64`, `linux-aarch64`, and `osx-arm64`. Merlin 1.1.2 is included on each
-of those platforms in the default environment.
+`linux-64`, `linux-aarch64`, and `osx-arm64`. Clone the
+[abecasis-lab-merlin](https://github.com/matthdsm/abecasis-lab-merlin)
+repository beside Hopla so pixi can install its `merlinpy` package:
+
+```text
+workspace/
+├── abecasis-lab-merlin/
+└── hopla/
+```
 
 ```bash
+cd workspace/hopla
 pixi install --locked
 pixi run hopla --help
 ```
 
-Use `pixi install --locked` so the committed `pixi.lock` is respected. Third-party
-lock entries are conda packages; the local package is the editable pixi path
-dependency, so `pixi install` puts `hopla` on the environment `PATH`.
+Use `pixi install --locked` so the committed `pixi.lock` is respected. The
+local Hopla package and sibling `merlinpy` package are editable pixi path
+dependencies; other third-party lock entries are conda packages.
 
-The default environment holds analysis dependencies and Merlin. The `dev`
-environment adds pytest, ruff, mypy, and typing stubs.
+The default environment holds analysis dependencies, including `merlinpy`.
+The `dev` environment adds pytest, ruff, mypy, and typing stubs.
 
 Pixi tasks (from the repository root):
 
@@ -31,10 +39,11 @@ After install, `pixi run hopla` invokes the console script (for example
 
 ## Pip (development tree)
 
-From the repository root, with a Python 3.12+ environment that already provides
-Merlin on `$PATH` when haplotyping is needed:
+From the Hopla repository root, with a Python 3.12+ environment and the Merlin
+repository cloned beside it:
 
 ```bash
+python -m pip install -e ../abecasis-lab-merlin
 python -m pip install -e '.[dev]'
 hopla --help
 ```
@@ -52,6 +61,7 @@ editable pip install:
   - cyvcf2
   - Jinja2
   - jsonschema
+  - merlinpy
   - numpy
   - plotly
   - polars
@@ -62,24 +72,26 @@ editable pip install:
   - Starlette
   - typer
   - Uvicorn
-- Standalone tools
-  - [Merlin](http://csg.sph.umich.edu/abecasis/merlin/index.html) (v1.1.2),
-    including the `merlin` and `minx` executables on `$PATH` when
-    `run_merlin` is enabled
 
-Merlin’s version should be exactly as given. The Merlin executables folder
-(`path/to/merlin-1.1.2/executables`) must be on `$PATH`, which is automatic
-with the pixi default environment. If `merlin` or `minx` is missing, or only
-one real sample is analyzed, the engine sets `run_merlin` to `false`.
+Hopla calls `merlinpy` in-process; the native `merlin` and `minx` executables
+are not required. If `merlinpy` is unavailable, or only one real sample is
+analyzed, the engine sets `run_merlin` to `false`.
+
+Build the container from the directory containing both repositories so the
+path dependency is in the Docker build context:
+
+```bash
+docker build -f hopla/Dockerfile -t hopla .
+```
 
 Hopla must not invoke Pandoc. The HTML report always inlines the offline
 `plotly.js` bundle shipped with the plotly package and gzip-compresses the
 columnar analysis payload for the browser to expand with
 `DecompressionStream`.
 
-Prefer adding Python dependencies in `pyproject.toml` under both `[project]`
-and `[tool.pixi.dependencies]` (or the `dev` extra / `[tool.pixi.feature.dev]`),
-then regenerate `pixi.lock` with pixi. Keep those dependencies available as
-conda packages so the lock stays free of third-party PyPI source builds.
+Prefer adding Python dependencies in `pyproject.toml` under `[project]` and
+the matching pixi conda or PyPI dependency section, then regenerate
+`pixi.lock` with pixi. Keep dependencies available as conda packages where
+possible; `merlinpy` is the explicit editable sibling-path exception.
 
 See [CHANGELOG.md](../CHANGELOG.md) for changes to the Python engine.

--- a/docs/install.md
+++ b/docs/install.md
@@ -6,24 +6,22 @@ environment).
 ## Pixi (Linux and macOS)
 
 The repository includes a locked [pixi](https://pixi.sh) environment for
-`linux-64`, `linux-aarch64`, and `osx-arm64`. Clone the
-[abecasis-lab-merlin](https://github.com/matthdsm/abecasis-lab-merlin)
-repository beside Hopla so pixi can install its `merlinpy` package:
-
-```text
-workspace/
-├── abecasis-lab-merlin/
-└── hopla/
-```
+`linux-64`, `linux-aarch64`, and `osx-arm64`. Clone with submodules so pixi
+can install `merlinpy` from
+[`vendor/abecasis-lab-merlin`](https://github.com/bioinformaticsorphanage/abecasis-lab-merlin):
 
 ```bash
-cd workspace/hopla
+git clone --recurse-submodules https://github.com/CenterForMedicalGeneticsGhent/Hopla
+cd Hopla
 pixi install --locked
 pixi run hopla --help
 ```
 
+If the clone already exists without the submodule, run
+`git submodule update --init vendor/abecasis-lab-merlin`.
+
 Use `pixi install --locked` so the committed `pixi.lock` is respected. The
-local Hopla package and sibling `merlinpy` package are editable pixi path
+local Hopla package and `merlinpy` submodule are editable pixi path
 dependencies; other third-party lock entries are conda packages.
 
 The default environment holds analysis dependencies, including `merlinpy`.
@@ -40,10 +38,11 @@ After install, `pixi run hopla` invokes the console script (for example
 ## Pip (development tree)
 
 From the Hopla repository root, with a Python 3.12+ environment and the Merlin
-repository cloned beside it:
+submodule initialized:
 
 ```bash
-python -m pip install -e ../abecasis-lab-merlin
+git submodule update --init vendor/abecasis-lab-merlin
+python -m pip install -e vendor/abecasis-lab-merlin
 python -m pip install -e '.[dev]'
 hopla --help
 ```
@@ -77,11 +76,11 @@ Hopla calls `merlinpy` in-process; the native `merlin` and `minx` executables
 are not required. If `merlinpy` is unavailable, or only one real sample is
 analyzed, the engine sets `run_merlin` to `false`.
 
-Build the container from the directory containing both repositories so the
-path dependency is in the Docker build context:
+Build the container from the repository root after initializing the submodule:
 
 ```bash
-docker build -f hopla/Dockerfile -t hopla .
+git submodule update --init vendor/abecasis-lab-merlin
+docker build -t hopla .
 ```
 
 Hopla must not invoke Pandoc. The HTML report always inlines the offline
@@ -92,6 +91,6 @@ columnar analysis payload for the browser to expand with
 Prefer adding Python dependencies in `pyproject.toml` under `[project]` and
 the matching pixi conda or PyPI dependency section, then regenerate
 `pixi.lock` with pixi. Keep dependencies available as conda packages where
-possible; `merlinpy` is the explicit editable sibling-path exception.
+possible; `merlinpy` is the explicit editable submodule-path exception.
 
 See [CHANGELOG.md](../CHANGELOG.md) for changes to the Python engine.

--- a/docs/output.md
+++ b/docs/output.md
@@ -123,10 +123,10 @@ ADO/ADI is not calculated.
 
 ### Haplotyping by Merlin
 
-Merlin runs when more than one real sample is in `family.members`, `run_merlin` is
-`true`, and the `merlin` / `minx` executables are on `$PATH`. There is no
-haplotyping when the family structure does not allow it (no reference sample
-means no breakpoints in the haplotyping strands).
+Merlin runs through `merlinpy` when more than one real sample is in
+`family.members`, `run_merlin` is `true`, and the package is available. There
+is no haplotyping when the family structure does not allow it (no reference
+sample means no breakpoints in the haplotyping strands).
 
 Haplotypes are coloured. Colours are relative between individuals and strands
 within a family. Hover a variant for details.

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -101,10 +101,9 @@ When more than one member is listed, at least one member must name a non-null
   When omitted or `null`, the model predicts sex (see `x_cutoff` and
   `y_cutoff`).
 - **`run_merlin`** (`boolean`, default `true`) Whether Merlin haplotyping should
-  run. The Merlin executables directory (`path/to/merlin-1.1.2/executables`)
-  must be on `$PATH`, which is automatic with the pixi default environment.
-  The engine forces `run_merlin` to `false` when only one real (non-ghost)
-  sample is present, or when `merlin` or `minx` is not found on `$PATH`.
+  run through the in-process `merlinpy` package. The engine forces
+  `run_merlin` to `false` when only one real (non-ghost) sample is present or
+  `merlinpy` is unavailable.
 
 The cytoband table is a CLI path (`-c CYTOBAND`), not a settings property. See
 [cli.md](cli.md).
@@ -183,6 +182,9 @@ cover that sample.
 - **`merlin_model`** (`sample` or `best`, default `best`) Underlying
   [Merlin haplotyping
   model](http://csg.sph.umich.edu/abecasis/merlin/tour/haplotyping.html).
+  `merlinpy` currently supports `sample` only for zero-bit families and raises
+  an error for informative pedigrees; use the default `best` for those
+  families.
 - **`min_seg_var`** (`number ≥ 0`, default `5`) Minimum number of variants in a
   same-haplotype segment. Segments that do not comply are corrected to the
   neighbouring haplotype. Corrected haplotypes use a circle symbol. Set to `0`

--- a/pixi.lock
+++ b/pixi.lock
@@ -166,8 +166,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.16.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/uvicorn-0.52.4-pyhc90fa1f_0.conda
-      - pypi: ../abecasis-lab-merlin
       - pypi: ./
+      - pypi: ./vendor/abecasis-lab-merlin
       linux-aarch64:
       - conda: https://conda.anaconda.org/bioconda/linux-aarch64/cyvcf2-0.34.0-py313h56f738b_0.conda
       - conda: https://conda.anaconda.org/bioconda/linux-aarch64/htslib-1.23.1-h58d2225_0.conda
@@ -309,8 +309,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.16.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/uvicorn-0.52.4-pyhc90fa1f_0.conda
-      - pypi: ../abecasis-lab-merlin
       - pypi: ./
+      - pypi: ./vendor/abecasis-lab-merlin
       osx-arm64:
       - conda: https://conda.anaconda.org/bioconda/osx-arm64/cyvcf2-0.34.0-py313he3ac920_0.conda
       - conda: https://conda.anaconda.org/bioconda/osx-arm64/htslib-1.23.1-h44a9eb5_0.conda
@@ -447,8 +447,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h74c22ad_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.3.2-h8088a28_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hf451053_7.conda
-      - pypi: ../abecasis-lab-merlin
       - pypi: ./
+      - pypi: ./vendor/abecasis-lab-merlin
   dev:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
@@ -613,8 +613,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.16.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/uvicorn-0.52.4-pyhc90fa1f_0.conda
-      - pypi: ../abecasis-lab-merlin
       - pypi: ./
+      - pypi: ./vendor/abecasis-lab-merlin
       linux-aarch64:
       - conda: https://conda.anaconda.org/bioconda/linux-aarch64/cyvcf2-0.34.0-py313h56f738b_0.conda
       - conda: https://conda.anaconda.org/bioconda/linux-aarch64/htslib-1.23.1-h58d2225_0.conda
@@ -772,8 +772,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.16.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/uvicorn-0.52.4-pyhc90fa1f_0.conda
-      - pypi: ../abecasis-lab-merlin
       - pypi: ./
+      - pypi: ./vendor/abecasis-lab-merlin
       osx-arm64:
       - conda: https://conda.anaconda.org/bioconda/osx-arm64/cyvcf2-0.34.0-py313he3ac920_0.conda
       - conda: https://conda.anaconda.org/bioconda/osx-arm64/htslib-1.23.1-h44a9eb5_0.conda
@@ -926,8 +926,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h74c22ad_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.3.2-h8088a28_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hf451053_7.conda
-      - pypi: ../abecasis-lab-merlin
       - pypi: ./
+      - pypi: ./vendor/abecasis-lab-merlin
 packages:
 - conda: https://conda.anaconda.org/bioconda/linux-64/cyvcf2-0.34.0-py313hd6fac57_0.conda
   sha256: cc4f8444289d38cea223f8f83cddd8e7270b4a9c3764e7c60f1d06f4d7a7affe
@@ -6890,12 +6890,6 @@ packages:
     - zstd >=1.5.7,<1.6.0a0
   size: 433687
   timestamp: 1786599629846
-- pypi: ../abecasis-lab-merlin
-  name: merlinpy
-  requires_dist:
-  - pytest>=8 ; extra == 'dev'
-  - ruff>=0.8 ; extra == 'dev'
-  requires_python: '>=3.12'
 - pypi: ./
   name: hopla
   requires_dist:
@@ -6919,4 +6913,10 @@ packages:
   - ruff ; extra == 'dev'
   - types-jsonschema ; extra == 'dev'
   - types-pyyaml ; extra == 'dev'
+  requires_python: '>=3.12'
+- pypi: ./vendor/abecasis-lab-merlin
+  name: merlinpy
+  requires_dist:
+  - pytest>=8 ; extra == 'dev'
+  - ruff>=0.8 ; extra == 'dev'
   requires_python: '>=3.12'

--- a/pixi.lock
+++ b/pixi.lock
@@ -28,7 +28,6 @@ environments:
       linux-64:
       - conda: https://conda.anaconda.org/bioconda/linux-64/cyvcf2-0.34.0-py313hd6fac57_0.conda
       - conda: https://conda.anaconda.org/bioconda/linux-64/htslib-1.23.1-h633afcb_0.conda
-      - conda: https://conda.anaconda.org/bioconda/linux-64/merlin-1.1.2-h3be2455_9.conda
       - conda: https://conda.anaconda.org/bioconda/linux-64/pybigwig-0.3.25-py313h759994b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.10.4-hb7a77c6_1.conda
@@ -167,11 +166,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.16.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/uvicorn-0.52.4-pyhc90fa1f_0.conda
+      - pypi: ../abecasis-lab-merlin
       - pypi: ./
       linux-aarch64:
       - conda: https://conda.anaconda.org/bioconda/linux-aarch64/cyvcf2-0.34.0-py313h56f738b_0.conda
       - conda: https://conda.anaconda.org/bioconda/linux-aarch64/htslib-1.23.1-h58d2225_0.conda
-      - conda: https://conda.anaconda.org/bioconda/linux-aarch64/merlin-1.1.2-h84a7dbf_9.conda
       - conda: https://conda.anaconda.org/bioconda/linux-aarch64/pybigwig-0.3.25-py313hfd04e6b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-auth-0.10.4-h03961ac_1.conda
@@ -310,11 +309,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.16.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/uvicorn-0.52.4-pyhc90fa1f_0.conda
+      - pypi: ../abecasis-lab-merlin
       - pypi: ./
       osx-arm64:
       - conda: https://conda.anaconda.org/bioconda/osx-arm64/cyvcf2-0.34.0-py313he3ac920_0.conda
       - conda: https://conda.anaconda.org/bioconda/osx-arm64/htslib-1.23.1-h44a9eb5_0.conda
-      - conda: https://conda.anaconda.org/bioconda/osx-arm64/merlin-1.1.2-h0babe12_9.conda
       - conda: https://conda.anaconda.org/bioconda/osx-arm64/pybigwig-0.3.25-py313h552ea20_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-doc-0.0.5-pyhcf101f3_0.conda
@@ -448,6 +447,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h74c22ad_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.3.2-h8088a28_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hf451053_7.conda
+      - pypi: ../abecasis-lab-merlin
       - pypi: ./
   dev:
     channels:
@@ -459,7 +459,6 @@ environments:
       linux-64:
       - conda: https://conda.anaconda.org/bioconda/linux-64/cyvcf2-0.34.0-py313hd6fac57_0.conda
       - conda: https://conda.anaconda.org/bioconda/linux-64/htslib-1.23.1-h633afcb_0.conda
-      - conda: https://conda.anaconda.org/bioconda/linux-64/merlin-1.1.2-h3be2455_9.conda
       - conda: https://conda.anaconda.org/bioconda/linux-64/pybigwig-0.3.25-py313h759994b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ast-serialize-0.8.0-py310hd8a072f_0.conda
@@ -614,11 +613,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.16.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/uvicorn-0.52.4-pyhc90fa1f_0.conda
+      - pypi: ../abecasis-lab-merlin
       - pypi: ./
       linux-aarch64:
       - conda: https://conda.anaconda.org/bioconda/linux-aarch64/cyvcf2-0.34.0-py313h56f738b_0.conda
       - conda: https://conda.anaconda.org/bioconda/linux-aarch64/htslib-1.23.1-h58d2225_0.conda
-      - conda: https://conda.anaconda.org/bioconda/linux-aarch64/merlin-1.1.2-h84a7dbf_9.conda
       - conda: https://conda.anaconda.org/bioconda/linux-aarch64/pybigwig-0.3.25-py313hfd04e6b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ast-serialize-0.8.0-py310h8c58d24_0.conda
@@ -773,11 +772,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.16.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/uvicorn-0.52.4-pyhc90fa1f_0.conda
+      - pypi: ../abecasis-lab-merlin
       - pypi: ./
       osx-arm64:
       - conda: https://conda.anaconda.org/bioconda/osx-arm64/cyvcf2-0.34.0-py313he3ac920_0.conda
       - conda: https://conda.anaconda.org/bioconda/osx-arm64/htslib-1.23.1-h44a9eb5_0.conda
-      - conda: https://conda.anaconda.org/bioconda/osx-arm64/merlin-1.1.2-h0babe12_9.conda
       - conda: https://conda.anaconda.org/bioconda/osx-arm64/pybigwig-0.3.25-py313h552ea20_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-doc-0.0.5-pyhcf101f3_0.conda
@@ -927,6 +926,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h74c22ad_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.3.2-h8088a28_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hf451053_7.conda
+      - pypi: ../abecasis-lab-merlin
       - pypi: ./
 packages:
 - conda: https://conda.anaconda.org/bioconda/linux-64/cyvcf2-0.34.0-py313hd6fac57_0.conda
@@ -969,22 +969,6 @@ packages:
     - htslib >=1.23.1,<1.24.0a0
   size: 1195461
   timestamp: 1773854995668
-- conda: https://conda.anaconda.org/bioconda/linux-64/merlin-1.1.2-h3be2455_9.conda
-  sha256: 650a21adb457d488dad93bb43b2fa2b581d9db2d876fcf72ad5abedc3801366e
-  md5: 144fbfd3ac996776a356145080877372
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - libzlib >=1.3.2,<2.0a0
-  - zlib
-  license: OpenSource
-  purls: []
-  run_exports:
-    weak:
-    - merlin >=1.1.2,<2.0a0
-  size: 742192
-  timestamp: 1787834893888
 - conda: https://conda.anaconda.org/bioconda/linux-64/pybigwig-0.3.25-py313h759994b_1.conda
   sha256: ac21f12e62a6a84e62f0bdc6598777cda618fcea52587e1d5dccb27d6e26cf7d
   md5: 15edb43c2b23dacfaa954a8935a93dfa
@@ -1044,21 +1028,6 @@ packages:
     - htslib >=1.23.1,<1.24.0a0
   size: 1403706
   timestamp: 1773854795190
-- conda: https://conda.anaconda.org/bioconda/linux-aarch64/merlin-1.1.2-h84a7dbf_9.conda
-  sha256: 278491c4a1dcb10a620b457429dca222095e92f6f1be841b1d3f12ca891eef62
-  md5: a6e7f1b7185afffe6f751e94c99ccc93
-  depends:
-  - libgcc >=14
-  - libstdcxx >=14
-  - libzlib >=1.3.2,<2.0a0
-  - zlib
-  license: OpenSource
-  purls: []
-  run_exports:
-    weak:
-    - merlin >=1.1.2,<2.0a0
-  size: 925384
-  timestamp: 1787834664773
 - conda: https://conda.anaconda.org/bioconda/linux-aarch64/pybigwig-0.3.25-py313hfd04e6b_1.conda
   sha256: aaced4cdbe3060c5488c5c3075c01716ce09dbc883e04b71ae3852ca363049d8
   md5: 9254ada2e51cffe153c441e918e7179f
@@ -1116,21 +1085,6 @@ packages:
     - htslib >=1.23.1,<1.24.0a0
   size: 992943
   timestamp: 1773854821372
-- conda: https://conda.anaconda.org/bioconda/osx-arm64/merlin-1.1.2-h0babe12_9.conda
-  sha256: 4b943a83c1a1d69c236324a28c4ec621dccee8690eed7d57f43271c2ded801a7
-  md5: 59208302d9e8219369d5588c162b77cd
-  depends:
-  - __osx >=11.0
-  - libcxx >=19
-  - libzlib >=1.3.2,<2.0a0
-  - zlib
-  license: OpenSource
-  purls: []
-  run_exports:
-    weak:
-    - merlin >=1.1.2,<2.0a0
-  size: 816797
-  timestamp: 1787834434876
 - conda: https://conda.anaconda.org/bioconda/osx-arm64/pybigwig-0.3.25-py313h552ea20_1.conda
   sha256: 5ec5b9ca5742c331e1369bae3381e78049ab7736d44f1f3138c50f463eb2c9fd
   md5: 1abdbf53f0484c6768893525b9edc94b
@@ -6936,12 +6890,19 @@ packages:
     - zstd >=1.5.7,<1.6.0a0
   size: 433687
   timestamp: 1786599629846
+- pypi: ../abecasis-lab-merlin
+  name: merlinpy
+  requires_dist:
+  - pytest>=8 ; extra == 'dev'
+  - ruff>=0.8 ; extra == 'dev'
+  requires_python: '>=3.12'
 - pypi: ./
   name: hopla
   requires_dist:
   - cyvcf2
   - jsonschema
   - jinja2
+  - merlinpy
   - numpy
   - plotly
   - polars

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ conda-pypi-map = { bioconda = { mapping = { pybigwig = "pybigwig" } } }
 
 [tool.pixi.pypi-dependencies]
 hopla = { path = ".", editable = true }
-merlinpy = { path = "../abecasis-lab-merlin", editable = true }
+merlinpy = { path = "vendor/abecasis-lab-merlin", editable = true }
 
 [tool.pixi.dependencies]
 python = ">=3.12,<3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
   "cyvcf2",
   "jsonschema",
   "jinja2",
+  "merlinpy",
   "numpy",
   "plotly",
   "polars",
@@ -77,6 +78,7 @@ conda-pypi-map = { bioconda = { mapping = { pybigwig = "pybigwig" } } }
 
 [tool.pixi.pypi-dependencies]
 hopla = { path = ".", editable = true }
+merlinpy = { path = "../abecasis-lab-merlin", editable = true }
 
 [tool.pixi.dependencies]
 python = ">=3.12,<3.14"
@@ -94,7 +96,6 @@ starlette = "*"
 typer = "*"
 uvicorn = "*"
 pip = "*"
-merlin = "1.1.2.*"
 
 [tool.pixi.feature.dev.dependencies]
 mypy = "*"

--- a/src/hopla/merlin.py
+++ b/src/hopla/merlin.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 import re
-import subprocess
 from pathlib import Path
+from typing import Literal, assert_never
 
 import numpy as np
 import polars as pl
+from merlinpy import run_best, run_error, run_sample
 
 from hopla.models import CHROMOSOMES, FilteredGenotypes, GenotypeMatrix, SiteTable
 from hopla.settings import Settings
@@ -128,27 +129,30 @@ def _write_inputs(
         )
 
 
-def _run_one(directory: Path, executable: str, suffix: str, model: str) -> None:
+def _run_one(directory: Path, suffix: str, model: Literal["sample", "best"]) -> None:
     """Run Merlin error detection then haplotyping for one chromosome group."""
     prefix = directory / f"merlin{suffix}"
-    common = ["-d", f"{prefix}.dat", "-p", f"{prefix}.ped", "-m", f"{prefix}.map"]
-    with (directory / f"merlin{suffix}.o").open("w", encoding="utf-8") as output:
-        subprocess.run(
-            [executable, *common, "--error", "--prefix", str(prefix)], check=True, stdout=output
-        )
+    dat_path = Path(f"{prefix}.dat")
+    ped_path = Path(f"{prefix}.ped")
+    map_path = Path(f"{prefix}.map")
+    chromosome_x = suffix == "X"
+    error_text = run_error(dat_path, ped_path, map_path, chromosome_x)
     errors = Path(f"{prefix}.err")
+    errors.write_text(error_text, encoding="utf-8")
     rejected = set()
     if errors.exists() and errors.stat().st_size:
         error_lines = errors.read_text(encoding="utf-8").splitlines()[1:]
         rejected = {columns[2] for line in error_lines if len(columns := line.split()) >= 3}
     if rejected:
         _remove_rejected_markers(prefix, {str(value) for value in rejected})
-    with (directory / f"merlin{suffix}.o").open("a", encoding="utf-8") as output:
-        subprocess.run(
-            [executable, *common, f"--{model}", "--prefix", str(prefix)],
-            check=True,
-            stdout=output,
-        )
+    if model == "best":
+        chromosome_text, flow_text = run_best(dat_path, ped_path, map_path, chromosome_x)
+    elif model == "sample":
+        chromosome_text, flow_text = run_sample(dat_path, ped_path, map_path, chromosome_x)
+    else:
+        assert_never(model)
+    Path(f"{prefix}.chr").write_text(chromosome_text, encoding="utf-8")
+    Path(f"{prefix}.flow").write_text(flow_text, encoding="utf-8")
 
 
 def _remove_rejected_markers(prefix: Path, rejected: set[str]) -> None:
@@ -228,8 +232,8 @@ def run_merlin(
     """Execute Merlin/minx and return corrected long-form haplotypes."""
     output_directory.mkdir(parents=True, exist_ok=True)
     _write_inputs(output_directory, sites, matrix, filtered, settings)
-    _run_one(output_directory, "merlin", "", settings.merlin_model)
-    _run_one(output_directory, "minx", "X", settings.merlin_model)
+    _run_one(output_directory, "", settings.merlin_model)
+    _run_one(output_directory, "X", settings.merlin_model)
     flow = _parse_blocks(output_directory / "merlin.flow", matrix.samples)
     flow.update(_parse_blocks(output_directory / "merlinX.flow", matrix.samples, ("chrX",)))
     geno = _parse_blocks(output_directory / "merlin.chr", matrix.samples)

--- a/src/hopla/settings.py
+++ b/src/hopla/settings.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import logging
 import re
-import shutil
+from importlib.util import find_spec
 from pathlib import Path
 from typing import Any, Literal
 
@@ -163,11 +163,7 @@ class Settings(BaseModel):
         self.dp_hard_limit_ids = self.dp_hard_limit_ids or sorted(parents)
         self.af_hard_limit_ids = self.af_hard_limit_ids or sorted(parents)
         self.dp_soft_limit_ids = self.dp_soft_limit_ids or terminal
-        if (
-            len(self.real_samples) == 1
-            or shutil.which("merlin") is None
-            or shutil.which("minx") is None
-        ):
+        if len(self.real_samples) == 1 or find_spec("merlinpy") is None:
             self.run_merlin = False
         return self
 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -122,7 +122,10 @@ def test_run_one_uses_merlinpy_and_removes_rejected_markers(
         )
         assert x_mode is chromosome_x
         calls.append("error")
-        return "    FAMILY     PERSON     MARKER      RATIO\n         1     SAMPLE        id2      0.001\n"
+        return (
+            "    FAMILY     PERSON     MARKER      RATIO\n"
+            "         1     SAMPLE        id2      0.001\n"
+        )
 
     def fake_best(dat: Path, ped: Path, mapfile: Path, x_mode: bool) -> tuple[str, str]:
         assert "id2" not in dat.read_text(encoding="utf-8")

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -4,13 +4,21 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
+from typing import Literal
 
 import numpy as np
 import pytest
 
+import hopla.merlin as merlin_module
 from hopla.analysis import _duo_errors, _trio_errors
 from hopla.filters import apply_filter1, apply_filter2
-from hopla.merlin import _marker_indices, _parse_blocks, correct_short_segments, weighted_vote
+from hopla.merlin import (
+    _marker_indices,
+    _parse_blocks,
+    _run_one,
+    correct_short_segments,
+    weighted_vote,
+)
 from hopla.models import GenotypeMatrix, SiteTable
 from hopla.pedigree import add_ghosts, predict_sexes
 from hopla.settings import Settings, load_settings, validate_settings
@@ -80,6 +88,65 @@ def test_parse_merlin_strand_pairs_and_wrapped_samples(tmp_path: Path) -> None:
     map_path.write_text("1\tid9\t1.0\nX\tid21\t2.0\n", encoding="utf-8")
     assert _marker_indices(map_path)["chr1"].tolist() == [8]
     assert _marker_indices(map_path)["chrX"].tolist() == [20]
+
+
+@pytest.mark.parametrize(
+    ("suffix", "model", "chromosome_x"),
+    [("", "best", False), ("X", "sample", True)],
+)
+def test_run_one_uses_merlinpy_and_removes_rejected_markers(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    suffix: str,
+    model: Literal["sample", "best"],
+    chromosome_x: bool,
+) -> None:
+    """Run both merlinpy phases and retain their compatibility output files."""
+    prefix = tmp_path / f"merlin{suffix}"
+    Path(f"{prefix}.dat").write_text("M id1\nM id2\n", encoding="utf-8")
+    Path(f"{prefix}.map").write_text(
+        f"{'X' if chromosome_x else '1'}\tid1\t1.0\n"
+        f"{'X' if chromosome_x else '1'}\tid2\t2.0\n",
+        encoding="utf-8",
+    )
+    Path(f"{prefix}.ped").write_text(
+        "1\tSAMPLE\t0\t0\t1\tA/A\tC/C\n", encoding="utf-8"
+    )
+    calls: list[str] = []
+
+    def fake_error(dat: Path, ped: Path, mapfile: Path, x_mode: bool) -> str:
+        assert (dat, ped, mapfile) == (
+            Path(f"{prefix}.dat"),
+            Path(f"{prefix}.ped"),
+            Path(f"{prefix}.map"),
+        )
+        assert x_mode is chromosome_x
+        calls.append("error")
+        return "    FAMILY     PERSON     MARKER      RATIO\n         1     SAMPLE        id2      0.001\n"
+
+    def fake_best(dat: Path, ped: Path, mapfile: Path, x_mode: bool) -> tuple[str, str]:
+        assert "id2" not in dat.read_text(encoding="utf-8")
+        assert "id2" not in mapfile.read_text(encoding="utf-8")
+        assert "C/C" not in ped.read_text(encoding="utf-8")
+        assert x_mode is chromosome_x
+        calls.append("best")
+        return "best chromosome\n", "best flow\n"
+
+    def fake_sample(dat: Path, ped: Path, mapfile: Path, x_mode: bool) -> tuple[str, str]:
+        chromosome_text, flow_text = fake_best(dat, ped, mapfile, x_mode)
+        calls[-1] = "sample"
+        return chromosome_text.replace("best", "sample"), flow_text.replace("best", "sample")
+
+    monkeypatch.setattr(merlin_module, "run_error", fake_error)
+    monkeypatch.setattr(merlin_module, "run_best", fake_best)
+    monkeypatch.setattr(merlin_module, "run_sample", fake_sample)
+
+    _run_one(tmp_path, suffix, model)
+
+    assert calls == ["error", model]
+    assert Path(f"{prefix}.err").read_text(encoding="utf-8").endswith("id2      0.001\n")
+    assert Path(f"{prefix}.chr").read_text(encoding="utf-8") == f"{model} chromosome\n"
+    assert Path(f"{prefix}.flow").read_text(encoding="utf-8") == f"{model} flow\n"
 
 
 def test_mixed_ploidy_and_absent_format_fields(tmp_path: Path) -> None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- replace native `merlin` and `minx` subprocesses with in-process `merlinpy` calls
- install `merlinpy` from a sibling checkout in pixi, CI, and Docker
- retain Merlin compatibility files and document the `sample` model limitation
- add focused coverage for autosomal and chromosome-X library dispatch

## Verification
- Pending
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-52570b57-b146-4e87-9a68-7e8b8f51881b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-52570b57-b146-4e87-9a68-7e8b8f51881b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

