### PR TITLE
Fix copy-number report y-axis to -5 to +5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ subtools, including historical notes from the predecessor R analysis pipeline.
 
 ## [Unreleased]
 
+### Changed
+
+- Copy-number report panels now use a fixed y-axis from -5 to +5 for every
+  sample. Windows with `|log2(ratio)| > 5` appear as red triangles on the
+  boundary; hover still shows the true value.
+
 ### Added
 
 - Added `sanitize_region` so settings load and the settings editor accept

--- a/docs/output.md
+++ b/docs/output.md
@@ -80,6 +80,10 @@ Windows without coverage have no finite log2 ratio. They are excluded from
 segmentation and from IGV tracks, and are flagged as `mask = false` in the
 portable `copy_number` table. Segments span across such gaps.
 
+Every sample panel uses a fixed y-axis from -5 to +5. Windows whose
+`|log2(ratio)|` is greater than 5 are drawn as red triangles on the
+corresponding boundary; hover still shows the true value.
+
 ## Filter 1: filter 0 plus `dp_hard_limit`, `af_hard_limit`, and `dp_soft_limit`
 
 Tables and plots applied to SNVs after those filters. See

--- a/src/hopla/report.js
+++ b/src/hopla/report.js
@@ -177,18 +177,25 @@
     BUILD.cn = function(spec){
       var d = D.copy_number.data;
       var mine = where('copy_number', function(d, i){ return d.sample[i] === spec.sample; });
-      var x = [], y = [], text = [];
+      var x = [], y = [], text = [], original = [], color = [], symbol = [], opacity = [];
       mine.forEach(function(i){
         var chrom = d.chrom[i], value = d.log2_ratio[i];
         if (OFF[chrom] === undefined || value === null || !isFinite(value)) return;
+        var high = value > 5, low = value < -5;
         x.push(OFF[chrom] + d.start[i]);
-        y.push(value);
+        y.push(high ? 5 : (low ? -5 : value));
         text.push(chrom + ':' + fmt(d.start[i]) + '-' + fmt(d.end[i]));
+        original.push(value);
+        color.push(high || low ? P[5] : P[0]);
+        symbol.push(high ? 'triangle-up' : (low ? 'triangle-down' : 'circle'));
+        opacity.push(high || low ? 1 : 0.6);
       });
-      var span = extent(y);
-      var range = [Math.min(-2.25, span[0]), Math.max(2.25, span[1])];
-      var traces = [{type:'scatter', mode:'markers', x:x, y:y, text:text, hoverinfo:'y+text',
-                     marker:{color:P[0], size:M.dot * 2, opacity:0.6}}];
+      var range = [-5, 5];
+      var traces = [{
+        type:'scatter', mode:'markers', x:x, y:y, text:text, customdata:original,
+        hovertemplate:'%{customdata}<br>%{text}<extra></extra>',
+        marker:{color:color, size:M.dot * 2, opacity:opacity, symbol:symbol}
+      }];
       if (has('cn_segments')){
         var s = D.cn_segments.data;
         where('cn_segments', function(s, i){ return s.sample[i] === spec.sample; }).forEach(function(i){
@@ -208,7 +215,7 @@
         traces: traces,
         layout: layout({
           height: spec.height, xtitle: M.labels[spec.sample], ytitle: 'log2(ratio)',
-          xaxis: chromosomeAxis(), yaxis: {range: range},
+          xaxis: chromosomeAxis(), yaxis: {range: range, fixedrange:true},
           shapes: chromosomeShapes(range[0], range[1]).concat(regionShapes(range[0], range[1], null, true))
         })
       };

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -235,6 +235,20 @@ def test_report_restores_every_original_section() -> None:
     assert "application/gzip+json" in html
 
 
+def test_copy_number_figure_uses_fixed_y_axis() -> None:
+    """Copy-number panels share -5 to +5 and mark clipped windows with red triangles."""
+    js = (Path(__file__).resolve().parents[1] / "src/hopla/report.js").read_text(encoding="utf-8")
+    cn = js.split("BUILD.cn = function", 1)[1].split("function bafTrace", 1)[0]
+    assert "var range = [-5, 5];" in cn
+    assert "fixedrange:true" in cn
+    assert "value > 5" in cn
+    assert "value < -5" in cn
+    assert "triangle-up" in cn
+    assert "triangle-down" in cn
+    assert "P[5]" in cn
+    assert "customdata" in cn
+
+
 def test_report_inlines_packaged_assets(tmp_path: Path) -> None:
     """Inline sibling CSS, JS, and the vendored plotly.js basic file."""
     package = Path(__file__).resolve().parents[1]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Copy-number panels now share a fixed y-axis from -5 to +5 for every sample.

Windows with `|log2(ratio)| > 5` are drawn as red outward triangles on the ±5 boundary. Hover still shows the true value. Segment mean lines are unchanged and Plotly clips them at the axis edge.

## Testing
- `pixi run -e dev lint-py`
- `pixi run -e dev test-py`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2136c5d7-7dd8-4b39-b4be-f8b6af12f432?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2136c5d7-7dd8-4b39-b4be-f8b6af12f432&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

