### PR TITLE
Write a tabix index when a bgzipped VCF has none

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ subtools, including historical notes from the predecessor R analysis pipeline.
 
 ## [Unreleased]
 
+### Added
+
+- Auto-generate a tabix `.tbi` next to a bgzip-compressed VCF when no sibling
+  index exists, so contig-parallel loading can proceed. An uncompressed VCF or
+  a failed index write still warns and falls back to a sequential scan.
+
 ### Fixed
 
 - Fixed the Galaxy `hopla3` analysis failing with `Settings file must use a

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -46,8 +46,9 @@ The Python engine is explicit and columnar:
    parents and sex directly from family members by ID.
 2. `vcf.py` streams selected biallelic SNVs with cyvcf2 into one `SiteTable`
    and compact sample-by-site NumPy matrices. Indexed VCFs load supported
-   contigs in a process pool (`hopla run -t`, default all CPUs). Without a
-   tabix or CSI index, loading warns and falls back to a single sequential
+   contigs in a process pool (`hopla run -t`, default all CPUs). A missing
+   tabix or CSI index on a bgzip-compressed VCF is written as `{vcf}.tbi` when
+   possible; otherwise loading warns and falls back to a single sequential
    scan.
 3. `filters.py`, `analysis.py`, and `merlin.py` operate on masks and matrices;
    they do not duplicate site columns per sample.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -37,7 +37,9 @@ hopla [-hV] [-L LEVEL] serve [--host HOST] [--port PORT]
   into a temporary directory for that run.
 - `-t THREADS` / `--threads THREADS` is the number of parallel VCF contig
   workers (default: all CPUs). Indexed VCFs (tabix `.tbi` or CSI `.csi`) load
-  contigs in a process pool. A missing index logs a warning and falls back to a
+  contigs in a process pool. A bgzip-compressed VCF with no sibling index gets
+  a tabix `.tbi` written next to it when the directory is writable. An
+  uncompressed VCF, or a failed index write, logs a warning and falls back to a
   single sequential scan. `-t 1` stays sequential without that warning.
 - `--export-parquet` / `--no-export-parquet` controls writing portable Parquet
   tables under `{family.id}-export/` (default: off).

--- a/docs/galaxy.md
+++ b/docs/galaxy.md
@@ -62,8 +62,9 @@ interactive report cannot render.
 Galaxy keeps a tabix index as dataset metadata for every `vcf_bgzip` dataset.
 The wrapper stages that index next to the staged VCF, so bgzip-compressed input
 is loaded contig-parallel across the job's allocated slots without asking the
-user for an index dataset. An uncompressed `vcf` dataset has no index and falls
-back to a single sequential scan.
+user for an index dataset. When that metadata is absent, Hopla writes a tabix
+index next to the staged VCF if the job directory is writable. An uncompressed
+`vcf` dataset has no index and falls back to a single sequential scan.
 
 ## Cytoband table
 

--- a/galaxy/hopla.xml
+++ b/galaxy/hopla.xml
@@ -120,8 +120,9 @@ YAML or JSON settings and writes a self-contained interactive HTML report,
 optionally with an archive of the Parquet or IGV exports.
 
 A bgzip-compressed VCF is read per contig with all allocated job slots, using
-the tabix index Galaxy keeps for the dataset. An uncompressed VCF is scanned
-sequentially.
+the tabix index Galaxy keeps for the dataset. If that index is missing, Hopla
+writes one next to the staged VCF when the job directory is writable. An
+uncompressed VCF is scanned sequentially.
 
 The cytoband table is read from the path in **UCSC hg38 cytoband table**, which
 must be readable from inside the job container. Clearing the field makes Hopla

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,7 @@ typer = "*"
 uvicorn = "*"
 pip = "*"
 merlin = "1.1.2.*"
+htslib = "*"
 
 [tool.pixi.feature.dev.dependencies]
 mypy = "*"

--- a/src/hopla/vcf.py
+++ b/src/hopla/vcf.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import logging
 import os
+import shutil
+import subprocess
 from collections.abc import Iterable
 from concurrent.futures import ProcessPoolExecutor
 from dataclasses import dataclass, field
@@ -102,6 +104,38 @@ def _has_index(path: Path) -> bool:
     return any(path.with_name(f"{path.name}{suffix}").is_file() for suffix in (".tbi", ".csi"))
 
 
+def _looks_bgzf(path: Path) -> bool:
+    """Return whether the file starts with gzip magic, as required for tabix."""
+    with path.open("rb") as handle:
+        return handle.read(2) == b"\x1f\x8b"
+
+
+def _ensure_index(path: Path) -> bool:
+    """Write a sibling tabix index for a BGZF VCF when none exists."""
+    if _has_index(path):
+        return True
+    if not _looks_bgzf(path):
+        return False
+    tabix = shutil.which("tabix")
+    if tabix is None:
+        logging.warning("tabix is not on PATH; VCF loading will be single-threaded.")
+        return False
+    logging.info("No tabix/CSI index found for %s; writing a tabix index.", path)
+    try:
+        subprocess.run([tabix, "-p", "vcf", str(path)], check=True, capture_output=True, text=True)
+    except (OSError, subprocess.CalledProcessError) as error:
+        detail: object = error
+        if isinstance(error, subprocess.CalledProcessError):
+            detail = (error.stderr or error.stdout or str(error)).strip()
+        logging.warning(
+            "Could not write a tabix index for %s: %s; VCF loading will be single-threaded.",
+            path,
+            detail,
+        )
+        return False
+    return _has_index(path)
+
+
 def _collect_variants(variants: Iterable[Any], sample_count: int) -> _CollectedSites:
     """Retain biallelic SNVs from a cyvcf2 iterator."""
     collected = _CollectedSites()
@@ -188,6 +222,7 @@ def load_vcf(
 ) -> tuple[SiteTable, GenotypeMatrix]:
     """Stream biallelic SNVs and selected sample FORMAT fields from a VCF."""
     resolved = os.cpu_count() or 1 if threads is None else threads
+    indexed = _ensure_index(path)
     reader = VCF(str(path), samples=list(samples), lazy=True)
     missing = set(samples) - set(reader.samples)
     if missing:
@@ -196,7 +231,6 @@ def load_vcf(
     # cyvcf2 yields subset columns in file order, so map them onto the requested order.
     file_order = list(reader.samples)
     permutation = np.asarray([file_order.index(sample) for sample in samples])
-    indexed = _has_index(path)
     contigs = _supported_contigs(reader.seqnames)
     workers = min(resolved, len(contigs)) if indexed else 1
     if resolved > 1 and not indexed:

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -341,23 +341,35 @@ def test_unindexed_vcf_warns_when_threads_exceed_one(
     assert np.array_equal(sequential_matrix.dp, parallel_matrix.dp)
 
 
-def _compress_and_index_vcf(plain: Path) -> Path:
-    """Bgzip and tabix-index a VCF, skipping when htslib tools are absent."""
+def _require_htslib() -> tuple[str, str]:
+    """Return bgzip and tabix paths, skipping when either tool is absent."""
     bgzip = shutil.which("bgzip")
     tabix = shutil.which("tabix")
     if bgzip is None or tabix is None:
         pytest.skip("bgzip and tabix are required to index a test VCF")
+    return bgzip, tabix
+
+
+def _compress_vcf(plain: Path) -> Path:
+    """Bgzip a VCF without writing an index."""
+    bgzip, _ = _require_htslib()
     compressed = Path(f"{plain}.gz")
     with compressed.open("wb") as handle:
         subprocess.run([bgzip, "-c", str(plain)], check=True, stdout=handle)
+    return compressed
+
+
+def _compress_and_index_vcf(plain: Path) -> Path:
+    """Bgzip and tabix-index a VCF, skipping when htslib tools are absent."""
+    _, tabix = _require_htslib()
+    compressed = _compress_vcf(plain)
     subprocess.run([tabix, "-p", "vcf", str(compressed)], check=True)
     return compressed
 
 
-def test_indexed_vcf_parallel_matches_sequential(tmp_path: Path) -> None:
-    """Read an indexed VCF by contig without changing retained sites or sample order."""
-    plain = tmp_path / "sites.vcf"
-    plain.write_text(
+def _write_two_contig_vcf(path: Path) -> None:
+    """Write a small two-contig VCF used by parallel-load tests."""
+    path.write_text(
         "\n".join(
             [
                 "##fileformat=VCFv4.2",
@@ -374,10 +386,40 @@ def test_indexed_vcf_parallel_matches_sequential(tmp_path: Path) -> None:
         + "\n",
         encoding="utf-8",
     )
+
+
+def test_indexed_vcf_parallel_matches_sequential(tmp_path: Path) -> None:
+    """Read an indexed VCF by contig without changing retained sites or sample order."""
+    plain = tmp_path / "sites.vcf"
+    _write_two_contig_vcf(plain)
     compressed = _compress_and_index_vcf(plain)
     samples = ("BBB", "AAA")
     sequential, sequential_matrix = load_vcf(compressed, samples, threads=1)
     parallel, parallel_matrix = load_vcf(compressed, samples, threads=4)
+    assert sequential.chrom.tolist() == parallel.chrom.tolist()
+    assert sequential.pos.tolist() == parallel.pos.tolist()
+    assert np.array_equal(sequential_matrix.gt, parallel_matrix.gt)
+    assert np.array_equal(sequential_matrix.dp, parallel_matrix.dp)
+
+
+def test_missing_index_is_written_for_bgzipped_vcf(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Write a tabix index next to a bgzipped VCF so parallel loading can proceed."""
+    plain = tmp_path / "sites.vcf"
+    _write_two_contig_vcf(plain)
+    compressed = _compress_vcf(plain)
+    index = Path(f"{compressed}.tbi")
+    assert not index.is_file()
+    samples = ("BBB", "AAA")
+    with caplog.at_level(logging.INFO):
+        sequential, sequential_matrix = load_vcf(compressed, samples, threads=1)
+    assert index.is_file()
+    assert "writing a tabix index" in caplog.text
+    caplog.clear()
+    with caplog.at_level(logging.WARNING):
+        parallel, parallel_matrix = load_vcf(compressed, samples, threads=4)
+    assert "single-threaded" not in caplog.text
     assert sequential.chrom.tolist() == parallel.chrom.tolist()
     assert sequential.pos.tolist() == parallel.pos.tolist()
     assert np.array_equal(sequential_matrix.gt, parallel_matrix.gt)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When `load_vcf` finds no sibling `.tbi` or `.csi`, it now runs `tabix -p vcf` next to a BGZF-compressed VCF so contig-parallel loading can proceed. Existing indexes are left alone. Uncompressed VCFs, a missing `tabix` binary, or a failed write still warn and fall back to a sequential scan.

`htslib` is pinned as an explicit pixi conda dependency so `tabix` stays on PATH in the default environment.

## Tests

- Keep the uncompressed-VCF warning test.
- Add coverage that bgzipping without an index creates `{vcf}.tbi` and that parallel results match sequential.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c47e4e9b-94bc-49dd-8de5-6f52783d7c0b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c47e4e9b-94bc-49dd-8de5-6f52783d7c0b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

